### PR TITLE
Tweaks to allow building on Ubuntu Focal (Linux) and macOS

### DIFF
--- a/emu-serial.c
+++ b/emu-serial.c
@@ -1,6 +1,5 @@
-
-#define _XOPEN_SOURCE  // for ptsname()
-#define _GNU_SOURCE  // for getpt()
+#define _DEFAULT_SOURCE  // for cfmakeraw()
+#define _XOPEN_SOURCE 500  // for ptsname()
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -9,6 +8,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <assert.h>
+#include <sys/select.h>
 
 #include "emu-serial.h"
 
@@ -65,7 +65,7 @@ void serial_init ()
 		{
 		// Create pseudo terminal for serial emulation
 
-		_ptm = getpt ();
+		_ptm = posix_openpt (O_RDWR);
 		if (_ptm < 0)
 			{
 			perror ("warning: cannot create PTM:");


### PR DESCRIPTION
The proposed changes:
  * To use `posix_openpt (.)` rather than `getpt ()` to get a pseudo-terminal master handle.  `getpt ()` only exists on Linux and not macOS --- this issue was reported at https://github.com/jbruchon/elks/pull/629#issuecomment-627951344 .
  * To change the feature test macros in order to properly get prototypes for `cfmakeraw (`...`)` and `ptsname (.)`, at least for newer versions of Ubuntu Linux.

Thank you!