### PR TITLE
Fixes to run with latest ELKS kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EMU86_PROG = emu86
 
 EMU86_HDRS = op-common.h op-id-name.h op-class.h emu-mem-io.h emu-proc.h emu-serial.h emu-int.h op-exec.h
 EMU86_SRCS = op-common.c op-id-name.c op-class.c emu-mem-io.c emu-proc.c emu-serial.c emu-int.c op-exec.c emu-main.c
-EMU86_OBJS = op-common.o op-id-name.o op-class.o emu-mem-io.o emu-proc.o emu-serial.o emu-int.o op-exec.o emu-main.o
+EMU86_OBJS = op-common.o op-id-name.o op-class.o emu-mem-io.o emu-proc.o emu-console.o emu-int.o op-exec.o emu-main.o
 
 # PCAT utility for EMU86 serial stub
 

--- a/emu-console.c
+++ b/emu-console.c
@@ -1,0 +1,99 @@
+#define _DEFAULT_SOURCE    // for cfmakeraw()
+#define _XOPEN_SOURCE 600  // for posix_openpt() & ptsname()
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <sys/select.h>
+#include <termios.h>
+//#include <fcntl.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+
+#include "emu-serial.h"
+
+static struct termios def_termios;
+
+void serial_send (byte_t c)
+	{
+	//if (c == '\n') serial_send ('\r');	// may be needed for Linux terminal
+	int n = write (1, &c, 1);
+	if (n != 1)
+		{
+		perror ("warning: cannot write to console:");  // TODO: propagate error
+		}
+	}
+
+
+byte_t serial_recv ()
+	{
+	byte_t c = 0xFF;
+
+	int n = read (0, &c, 1);
+	if (n == 0) return 0;
+	if (n != 1)
+		{
+		perror ("warning: cannot read from PTM:");  // TODO: propagate error
+		}
+	if (c == 0x7f) c = '\b';	// convert DEL to BS
+
+	return c;
+	}
+
+
+byte_t serial_poll ()
+	{
+	fd_set fdsr;
+	FD_ZERO (&fdsr);
+	FD_SET (0, &fdsr);
+	struct timeval tv = { 0L, 0L };  // immediate
+	int s = select (1, &fdsr, NULL, NULL, &tv);
+	assert (s >= 0);
+	if (FD_ISSET (0, &fdsr)) return 1;
+	return 0;
+	}
+
+
+void serial_catch ()
+{
+	extern int flag_prompt;
+
+	flag_prompt = 1;
+}
+
+void serial_raw ()
+	{
+	struct termios termios;
+	tcgetattr(0, &termios);
+	termios.c_iflag &= ~(ICRNL|IGNCR|INLCR|IXON|IXOFF);
+	//termios.c_oflag &= ~(OPOST);
+	termios.c_lflag &= ~(ECHO|ECHOE|ECHONL|ICANON);
+	tcsetattr(0, TCSANOW, &termios);
+
+	int nonblock = 1;
+	ioctl(0, FIONBIO, &nonblock);
+	}
+
+void serial_normal ()
+	{
+	int nonblock = 0;
+	ioctl(0, FIONBIO, &nonblock);
+	tcsetattr(0, TCSANOW, &def_termios);
+	}
+
+void serial_init ()
+	{
+	tcgetattr(0, &def_termios);
+	signal(SIGINT, serial_catch);
+	serial_raw();
+	}
+
+
+void serial_term ()
+	{
+	serial_normal();
+	}

--- a/emu-console.c
+++ b/emu-console.c
@@ -1,6 +1,3 @@
-#define _DEFAULT_SOURCE    // for cfmakeraw()
-#define _XOPEN_SOURCE 600  // for posix_openpt() & ptsname()
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <fcntl.h>
@@ -10,7 +7,6 @@
 #include <assert.h>
 #include <sys/select.h>
 #include <termios.h>
-//#include <fcntl.h>
 #include <signal.h>
 #include <sys/ioctl.h>
 
@@ -37,7 +33,7 @@ byte_t serial_recv ()
 	if (n == 0) return 0;
 	if (n != 1)
 		{
-		perror ("warning: cannot read from PTM:");  // TODO: propagate error
+		perror ("warning: cannot read from console:");  // TODO: propagate error
 		}
 	if (c == 0x7f) c = '\b';	// convert DEL to BS
 

--- a/emu-main.c
+++ b/emu-main.c
@@ -77,6 +77,7 @@ static int file_load (addr_t start, char * path)
 
 
 // Program main
+int flag_prompt = 0;
 
 int main (int argc, char * argv [])
 	{
@@ -94,7 +95,6 @@ int main (int argc, char * argv [])
 		addr_t break_code_addr = -1;
 
 		int flag_trace = 0;
-		int flag_prompt = 0;
 
 		// Auto check
 
@@ -299,14 +299,10 @@ int main (int argc, char * argv [])
 				{
 				// Print processor status
 
-				putchar ('\n');
-				regs_print ();
-				putchar ('\n');
-
 				printf ("%.4hX:%.4hX  ", seg_get (SEG_CS), reg16_get (REG_IP));
 				print_column (op_code_str, 3 * OPCODE_MAX + 1);
 				print_op (&desc);
-				puts ("\n");
+				putchar ('\n');
 				}
 
 			// User prompt
@@ -316,18 +312,29 @@ int main (int argc, char * argv [])
 				// Get user command
 				// Ugly but temporary
 
+				serial_normal();
 				char com [8];
+				if (!flag_trace) putchar ('\n');
 				putchar ('>');
 				char * res = fgets (com, 8, stdin);
 				if (!res) break;
+				serial_raw();
 
 				switch (com [0])
 					{
 					// Dump stack
 
 					case 's':
-						putchar ('\n');
 						stack_print ();
+						flag_trace = 0;
+						flag_exec = 0;
+						break;
+
+					// Print registers
+
+					case 'r':
+						regs_print ();
+						flag_trace = 0;
 						flag_exec = 0;
 						break;
 
@@ -336,6 +343,21 @@ int main (int argc, char * argv [])
 					case 'p':
 						break_code_addr = addr_seg_off (op_code_seg, op_code_off);
 						flag_trace = 0;
+						flag_prompt = 0;
+						break;
+
+					// Trace one step
+
+					case 't':
+					case '\n':
+						flag_trace = 1;
+						flag_prompt = 1;
+						break;
+
+					// Continue tracing
+
+					case 'c':
+						flag_trace = 1;
 						flag_prompt = 0;
 						break;
 

--- a/emu-serial.h
+++ b/emu-serial.h
@@ -11,3 +11,7 @@ byte_t serial_poll ();
 
 void serial_init ();
 void serial_term ();
+
+// console only
+void serial_raw ();
+void serial_normal ();

--- a/op-exec.c
+++ b/op-exec.c
@@ -735,6 +735,12 @@ static int op_shift_rot (op_desc_t * op_desc)
 				flag_set (FLAG_OF, c ^ t);
 				}
 
+			if (id == OP_SHL)
+				{
+				flag_set (FLAG_ZF, a == 0);
+				flag_set (FLAG_SF, (a & 0x8000) != 0);
+				}
+
 			break;
 
 		case OP_RCR:
@@ -763,6 +769,12 @@ static int op_shift_rot (op_desc_t * op_desc)
 				q = q ? 1 : 0;
 
 				flag_set (FLAG_OF, t ^ q);
+				}
+
+			if (id == OP_SHR || id == OP_SAR)
+				{
+				flag_set (FLAG_ZF, a == 0);
+				flag_set (FLAG_SF, (a & 0x8000) != 0);
 				}
 
 			break;
@@ -1440,7 +1452,7 @@ static int op_xlat (op_desc_t * op_desc)
 	assert (op_desc->var_count == 0);
 
 	word_t bx = reg16_get (REG_BX);
-	word_t ds = reg16_get (REG_BX);
+	word_t ds = seg_get (SEG_DS);
 
 	addr_t a = addr_seg_off (ds, bx + (word_t) reg8_get (REG_AL));
 	reg8_set (REG_AL, mem_read_byte (a));


### PR DESCRIPTION
Hello @mfld-fr!

I want to say what a great project emu86 is. Very well done, I am very impressed.

From some of the comments you made on sys86, I decided to learn about emu86 and to see how it works emulating ELKS and a ROM filesystem. It took a bit, but I now have the latest ELKS kernel configured with config-emu86/CONFIG_ROMCODE (not fartext, though) running well on emu86.

This is a super tool for understanding exactly what will be needed on the ADVTECH SNMP-1000 board, as well as what ELKS requires from a standalone system BIOS. I am thinking of continuing to use this to possibly port ELKS to more bare-bones standalone systems.

In the process, which took awhile, I figured out some bugs in emu86 instruction emulation:
- SHR, SAR and SHL don't set S or Z flags, and need to.
- XLAT is coded incorrectly, doesn't use DS properly.

The SHR Z flag bug became a problem with @tkchia's commit https://github.com/jbruchon/elks/commit/de499c25711319e0bbb9ee564589dc1e611c8ed6 which replaced the older ELKS version of __udivsi3 with another version that depends on SHR and the Z flag working to spec.

The XLAT instruction is emitted by gcc on longer switch statements. This was found in the middle of the libc getpwuid function when running "ls -l" hung ELKS in the emulator, which uses an 8-case switch statement.

Because the process of debugging ELKS with emu86 caused the interpreter to sometimes loop without being able to be interrupted, because emu86 is running in the background and accessed only through pcat, I decide to write another "serial" interface to emu86, which has a number of benefits:
- No PTY serial driver, uses stdin/stdout
- Ability to ^C the emulator and gain access to the interactive ">" prompt at any time.
- Ability to continue the emulator with or without instruction tracing and still have ELKS "BIOS console" access working. New monitor commands added:
    - c - Continue with instruction tracing
    - t - Trace one instruction
    - r - show Registers

With these changes, it doesn't take long to debug various aspects of the entire system, thanks to a very well designed emu86!

The newer driver is emu-console.c, which replaces emu-serial.c by default. Pcat is not longer required.
This has been fully tested on macOS and should run fine on Linux, with the possible exception of uncommenting a line in serial_send which outputs a CR before NL (macOS terminal always has ONLCR on, some Linux seem not to).
