### PR TITLE
Add AT&T-style instruction mnemonic display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ EMU86_HDRS = op-common.h op-id-name.h op-class.h emu-mem-io.h emu-proc.h emu-ser
 EMU86_SRCS = op-common.c op-id-name.c op-class.c emu-mem-io.c emu-proc.c emu-serial.c emu-int.c op-exec.c emu-main.c
 EMU86_OBJS = op-common.o op-id-name.o op-class.o emu-mem-io.o emu-proc.o emu-console.o emu-int.o op-exec.o emu-main.o
 
+STYLE=att
+#STYLE=intel
+
+EMU86_OBJS += op-print-$(STYLE).o
+
 # PCAT utility for EMU86 serial stub
 
 PCAT_PROG = pcat

--- a/op-common.c
+++ b/op-common.c
@@ -41,21 +41,3 @@ void print_column (char * s, byte_t w)
 		d++;
 		}
 	}
-
-
-// Print a relative number with optional sign prefix
-
-void print_rel (byte_t prefix, short rel)
-	{
-	if (rel >= 0)
-		{
-		if (prefix) putchar ('+');
-		}
-	else
-		{
-		putchar ('-');
-		rel = -rel;
-		}
-
-	printf ("%hXh", (word_t) rel);
-	}

--- a/op-id-name.c
+++ b/op-id-name.c
@@ -108,7 +108,7 @@ static op_id_name_t id_name_tab [] = {
 	};
 
 
-char *op_id_to_name (word_t op_id)
+char *op_id_to_name (word_t op_id, word_t lower)
 	{
 	char *name = NULL;
 	op_id_name_t *op = id_name_tab;
@@ -125,5 +125,17 @@ char *op_id_to_name (word_t op_id)
 		op++;
 		}
 
+	if (lower)
+		{
+		static char buf[10];
+		char *p = name;
+		char *q = buf;
+		while (*p)
+			{
+			*q++ = *p++ - 'A' + 'a';
+			}
+		*q = 0;
+		return buf;
+		}
 	return name;
 	}

--- a/op-id-name.h
+++ b/op-id-name.h
@@ -4,4 +4,4 @@
 #include "op-common.h"
 
 
-char *op_id_to_name (word_t op_id);
+char *op_id_to_name (word_t op_id, word_t lower);

--- a/op-print-att.c
+++ b/op-print-att.c
@@ -1,0 +1,201 @@
+// LIB86 - 80x86 library
+// Operation classes
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "op-id.h"
+#include "op-id-name.h"
+#include "op-class.h"
+
+
+// Opcode helpers
+
+extern byte_t * op_code_base;
+extern word_t op_code_seg;
+extern word_t op_code_off;
+
+char op_code_str [3 * OPCODE_MAX + 2];
+byte_t op_code_pos;
+
+
+// Register class
+
+static char * reg8_names  [] = { "%al", "%cl", "%dl", "%bl", "%ah", "%ch", "%dh", "%bh" };
+static char * reg16_names [] = { "%ax", "%cx", "%dx", "%bx", "%sp", "%bp", "%si", "%di" };
+static char * seg_names   [] = { "%es", "%cs", "%ss", "%ds" };
+
+static void print_reg (byte_t type, byte_t num)
+	{
+	switch (type)
+		{
+		case RT_REG8:
+			print_string (reg8_names [num]);
+			break;
+
+		case RT_REG16:
+			print_string (reg16_names [num]);
+			break;
+
+		case RT_SEG:
+			print_string (seg_names [num]);
+			break;
+		}
+	}
+
+
+static void print_mem (byte_t flags, short rel)
+	{
+	byte_t reg;
+
+	reg = 0;
+
+	if (flags & AF_DISP)
+		{
+		if (flags & (AF_BX|AF_BP|AF_SI|AF_DI))
+			{
+			print_rel (1, rel);
+			}
+		else
+			{
+			printf ("0x%hx", (word_t) rel);
+			}
+		}
+
+	if (flags & (AF_BX|AF_BP|AF_SI|AF_DI))
+		{
+		putchar ('(');
+		}
+
+	if (flags & AF_BX)
+		{
+		print_string ("%bx");
+		reg = 1;
+		}
+
+	if (flags & AF_BP)
+		{
+		print_string ("%bp");
+		reg = 1;
+		}
+
+	if (flags & AF_SI)
+		{
+		if (reg) putchar ('+');
+		print_string ("%si");
+		reg = 1;
+		}
+
+	if (flags & AF_DI)
+		{
+		if (reg) putchar ('+');
+		print_string ("%di");
+		}
+
+	if (flags & (AF_BX|AF_BP|AF_SI|AF_DI))
+		{
+		putchar (')');
+		}
+	}
+
+
+// Variable class
+
+static void print_var (op_var_t * var)
+	{
+	switch (var->type)
+		{
+		case VT_IMM:
+			if (var->s)
+				{
+				printf ("$0x%.2x", var->val.s);
+				break;
+				}
+
+			if (var->w)
+				{
+				printf ("$0x%.4x", var->val.w);
+				break;
+				}
+
+			printf ("$0x%.2x", var->val.b);
+			break;
+
+		case VT_REG:
+			print_reg (var->w ? RT_REG16 : RT_REG8, var->val.r);
+			break;
+
+		case VT_SEG:
+			print_reg (RT_SEG, var->val.r);
+			break;
+
+		case VT_MEM:
+			print_mem (var->flags, var->val.s);
+			break;
+
+		case VT_LOC:
+			if (var->far)
+				{
+				// Far address is absolute
+
+				printf ("0x%.4x",var->seg);
+				putchar (':');
+				printf ("0x%.4x",var->val.w);
+				break;
+				}
+
+			// Near address is relative
+
+			printf ("%.4x", (word_t) ((short) op_code_off + var->val.s));
+			break;
+
+		}
+	}
+
+
+// Print a relative number with optional sign prefix
+
+void print_rel (byte_t prefix, short rel)
+	{
+	if (rel < 0)
+		{
+		putchar ('-');
+		rel = -rel;
+		}
+
+	printf ("0x%hx", (word_t) rel);
+	}
+
+
+// Operation classes
+
+void print_op (op_desc_t * op_desc)
+	{
+	char *name = op_id_to_name (OP_ID, 1);
+	if (!name) name = "???";
+	print_column (name, OPNAME_MAX + 2);
+
+	byte_t count = op_desc->var_count;
+
+	// Special case for string operations
+
+	if (!count && (OP_ID >= OP_STRING0) && (OP_ID < OP_STRING0 + 8))
+		{
+		printf (op_desc->w2 ? "WORD" : "BYTE");
+		}
+
+	// Common cases
+
+	if (count >= 2)
+		{
+		print_var (&(op_desc->var_from));
+		putchar (',');
+		}
+
+	if (count >= 1)
+		{
+		print_var (&(op_desc->var_to));
+		}
+	}

--- a/op-print-intel.c
+++ b/op-print-intel.c
@@ -1,0 +1,199 @@
+// LIB86 - 80x86 library
+// Operation classes
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "op-id.h"
+#include "op-id-name.h"
+#include "op-class.h"
+
+
+// Opcode helpers
+
+extern byte_t * op_code_base;
+extern word_t op_code_seg;
+extern word_t op_code_off;
+
+char op_code_str [3 * OPCODE_MAX + 2];
+byte_t op_code_pos;
+
+
+// Register class
+
+static char * reg8_names  [] = { "AL", "CL", "DL", "BL", "AH", "CH", "DH", "BH" };
+static char * reg16_names [] = { "AX", "CX", "DX", "BX", "SP", "BP", "SI", "DI" };
+static char * seg_names   [] = { "ES", "CS", "SS", "DS" };
+
+static void print_reg (byte_t type, byte_t num)
+	{
+	switch (type)
+		{
+		case RT_REG8:
+			print_string (reg8_names [num]);
+			break;
+
+		case RT_REG16:
+			print_string (reg16_names [num]);
+			break;
+
+		case RT_SEG:
+			print_string (seg_names [num]);
+			break;
+		}
+	}
+
+
+static void print_mem (byte_t flags, short rel)
+	{
+	byte_t reg;
+
+	reg = 0;
+	putchar ('[');
+
+	if (flags & AF_BX)
+		{
+		print_string ("BX");
+		reg = 1;
+		}
+
+	if (flags & AF_BP)
+		{
+		print_string ("BP");
+		reg = 1;
+		}
+
+	if (flags & AF_SI)
+		{
+		if (reg) putchar ('+');
+		print_string ("SI");
+		reg = 1;
+		}
+
+	if (flags & AF_DI)
+		{
+		if (reg) putchar ('+');
+		print_string ("DI");
+		reg = 1;
+		}
+
+	if (flags & AF_DISP)
+		{
+		if (reg)
+			{
+			print_rel (1, rel);  // with prefix
+			}
+		else
+			{
+			printf ("%hXh", (word_t) rel);
+			}
+		}
+
+	putchar (']');
+	}
+
+
+// Variable class
+
+static void print_var (op_var_t * var)
+	{
+	switch (var->type)
+		{
+		case VT_IMM:
+			if (var->s)
+				{
+				print_rel (0, var->val.s);
+				break;
+				}
+
+			if (var->w)
+				{
+				printf ("%.4Xh", var->val.w);
+				break;
+				}
+
+			printf ("%.2Xh", var->val.b);
+			break;
+
+		case VT_REG:
+			print_reg (var->w ? RT_REG16 : RT_REG8, var->val.r);
+			break;
+
+		case VT_SEG:
+			print_reg (RT_SEG, var->val.r);
+			break;
+
+		case VT_MEM:
+			print_mem (var->flags, var->val.s);
+			break;
+
+		case VT_LOC:
+			if (var->far)
+				{
+				// Far address is absolute
+
+				printf ("%.4Xh",var->seg);
+				putchar (':');
+				printf ("%.4Xh",var->val.w);
+				break;
+				}
+
+			// Near address is relative
+
+			printf ("%.4Xh", (word_t) ((short) op_code_off + var->val.s));
+			break;
+
+		}
+	}
+
+
+// Print a relative number with optional sign prefix
+
+void print_rel (byte_t prefix, short rel)
+	{
+	if (rel >= 0)
+		{
+		if (prefix) putchar ('+');
+		}
+	else
+		{
+		putchar ('-');
+		rel = -rel;
+		}
+
+	printf ("%hXh", (word_t) rel);
+	}
+
+
+// Operation classes
+
+void print_op (op_desc_t * op_desc)
+	{
+	char *name = op_id_to_name (OP_ID, 0);
+	if (!name) name = "???";
+	print_column (name, OPNAME_MAX + 2);
+
+	byte_t count = op_desc->var_count;
+
+	// Special case for string operations
+
+	if (!count && (OP_ID >= OP_STRING0) && (OP_ID < OP_STRING0 + 8))
+		{
+		printf (op_desc->w2 ? "WORD" : "BYTE");
+		}
+
+	// Common cases
+
+	if (count >= 1)
+		{
+		print_var (&(op_desc->var_to));
+		}
+
+	if (count >= 2)
+		{
+		putchar (',');
+		print_var (&(op_desc->var_from));
+		}
+	}


### PR DESCRIPTION
Moves printing to separate source modules as requested in #1.

Adds optional GCC gas-compatible AT&T style instruction format display to EMU86.

Both Intel and AT&T style display supported, option specified in Makefile. AT&T display set as new default.