### PR TITLE
Minor fixes to AT&T display and ^S/^Q usage

### DIFF
--- a/emu-console.c
+++ b/emu-console.c
@@ -65,7 +65,7 @@ void serial_raw ()
 	{
 	struct termios termios;
 	tcgetattr(0, &termios);
-	termios.c_iflag &= ~(ICRNL|IGNCR|INLCR|IXON|IXOFF);
+	termios.c_iflag &= ~(ICRNL|IGNCR|INLCR);
 	//termios.c_oflag &= ~(OPOST);
 	termios.c_lflag &= ~(ECHO|ECHOE|ECHONL|ICANON);
 	tcsetattr(0, TCSANOW, &termios);

--- a/op-print-att.c
+++ b/op-print-att.c
@@ -83,14 +83,14 @@ static void print_mem (byte_t flags, short rel)
 
 	if (flags & AF_SI)
 		{
-		if (reg) putchar ('+');
+		if (reg) putchar (',');
 		print_string ("%si");
 		reg = 1;
 		}
 
 	if (flags & AF_DI)
 		{
-		if (reg) putchar ('+');
+		if (reg) putchar (',');
 		print_string ("%di");
 		}
 
@@ -110,7 +110,7 @@ static void print_var (op_var_t * var)
 		case VT_IMM:
 			if (var->s)
 				{
-				printf ("$0x%.2x", var->val.s);
+				printf ("$0x%.2x", var->val.s & 0xFFFF);
 				break;
 				}
 


### PR DESCRIPTION
Fixes (%bx,%di) display.
Restricts sign extension to word on display of signed negative offsets.
Allows use of ^S/^Q during c)ontinue instruction tracing.

I'm not sure the instruction "FF 36 01 00" is being displayed properly: "PUSH 0x0001". Should that be "PUSH $0x0001"?
Not sure how to fix this.

I'm also not sure how to test the proper display of instructions that need BYTE or WORD arguments: 

"mov $0,0x40" - would that be a byte or word move of 0 to DS:0x40? Haven't seen this in the instruction stream.

Thinking of adding a way to change a memory location or register and then executing there to display an instruction, or can you think of an easier way to do this?