### PR TITLE
More explicit operand size

### DIFF
--- a/op-class.c
+++ b/op-class.c
@@ -357,7 +357,7 @@ static int class_mod_rm (byte_t flags, op_desc_t * op)
 	}
 
 
-static int class_w_mod_rm (byte_t flags, op_desc_t * op)
+static int class_w_mod_rm (byte_t flags, op_desc_t * op) //YYY
 	{
 	op->var_count = 1;
 
@@ -384,6 +384,10 @@ static int class_w_mod_rm (byte_t flags, op_desc_t * op)
 			var_num->s = 0;
 			var_num->val.b = 1;
 			}
+		}
+		else
+		{
+		op->var_wb = op->w2 + 1; // "inc 0x1234"
 		}
 
 	return 0;
@@ -667,6 +671,7 @@ static int class_1_80h (byte_t code, op_desc_t * op_desc)
 					{
 					OP_ID = OP_CALC2 + op_desc->reg2;
 					err = class_w_mod_rm_imm (CF_S, op_desc);  // TODO: S not compliant for all operations
+					op_desc->var_wb = op_desc->w2 + 1; // "cmp $0,0x1234"
 					break;
 					}
 
@@ -829,6 +834,7 @@ static int class_1_C0h (byte_t code, op_desc_t * op_desc)
 
 				OP_ID = OP_MOV;
 				err = class_w_mod_rm_imm (0, op_desc);
+				op_desc->var_wb = op_desc->w2 + 1; // "mov $0,0x1234"
 				break;
 				}
 

--- a/op-class.c
+++ b/op-class.c
@@ -357,7 +357,7 @@ static int class_mod_rm (byte_t flags, op_desc_t * op)
 	}
 
 
-static int class_w_mod_rm (byte_t flags, op_desc_t * op) //YYY
+static int class_w_mod_rm (byte_t flags, op_desc_t * op)
 	{
 	op->var_count = 1;
 

--- a/op-class.h
+++ b/op-class.h
@@ -72,17 +72,21 @@ typedef struct op_var_s op_var_t;
 
 // Operation
 
+#define VP_BYTE   1     // byte instruction printing
+#define VP_WORD   2     // word instruction printing
+
 struct op_desc_s
 	{
 	word_t    op_id;    // operation identifier
 
 	byte_t   var_count; // operand count
+	byte_t   var_wb;    // operand is =1 byte, =2 word (for printing)
 	op_var_t var_to;    // optional single or 'to' operand
 	op_var_t var_from;  // optional 'from' operand
 
 	// opcode 1 byte fields
 
-	byte_t v1;;         // variable flag (for in and out)
+	byte_t v1;          // variable flag (for in and out)
 	byte_t w1;          // w flag 1
 	byte_t seg1;        // segment number
 	byte_t reg1;        // register number

--- a/op-id-name.c
+++ b/op-id-name.c
@@ -4,6 +4,7 @@
 
 #include "op-id.h"
 #include "op-id-name.h"
+#include "op-class.h"
 
 
 struct op_id_name_s
@@ -108,7 +109,7 @@ static op_id_name_t id_name_tab [] = {
 	};
 
 
-char *op_id_to_name (word_t op_id, word_t lower)
+char *op_id_to_name (word_t op_id, word_t lower, byte_t wb)
 	{
 	char *name = NULL;
 	op_id_name_t *op = id_name_tab;
@@ -127,13 +128,17 @@ char *op_id_to_name (word_t op_id, word_t lower)
 
 	if (lower)
 		{
-		static char buf[10];
+		static char buf[OPNAME_MAX+2];
 		char *p = name;
 		char *q = buf;
 		while (*p)
 			{
 			*q++ = *p++ - 'A' + 'a';
 			}
+		if (wb == VP_WORD)
+			*q++ = 'w';
+		if (wb == VP_BYTE)
+			*q++ = 'b';
 		*q = 0;
 		return buf;
 		}

--- a/op-id-name.h
+++ b/op-id-name.h
@@ -4,4 +4,4 @@
 #include "op-common.h"
 
 
-char *op_id_to_name (word_t op_id, word_t lower);
+char *op_id_to_name (word_t op_id, word_t lower, byte_t wb);

--- a/op-print-att.c
+++ b/op-print-att.c
@@ -173,18 +173,18 @@ void print_rel (byte_t prefix, short rel)
 
 void print_op (op_desc_t * op_desc)
 	{
-	char *name = op_id_to_name (OP_ID, 1);
-	if (!name) name = "???";
-	print_column (name, OPNAME_MAX + 2);
-
 	byte_t count = op_desc->var_count;
 
 	// Special case for string operations
 
 	if (!count && (OP_ID >= OP_STRING0) && (OP_ID < OP_STRING0 + 8))
 		{
-		printf (op_desc->w2 ? "WORD" : "BYTE");
+		op_desc->var_wb = op_desc->w2 + 1;
 		}
+
+	char *name = op_id_to_name (OP_ID, 1, op_desc->var_wb);
+	if (!name) name = "???";
+	print_column (name, OPNAME_MAX + 2);
 
 	// Common cases
 

--- a/op-print-intel.c
+++ b/op-print-intel.c
@@ -171,7 +171,7 @@ void print_rel (byte_t prefix, short rel)
 
 void print_op (op_desc_t * op_desc)
 	{
-	char *name = op_id_to_name (OP_ID, 0);
+	char *name = op_id_to_name (OP_ID, 0, 0);
 	if (!name) name = "???";
 	print_column (name, OPNAME_MAX + 2);
 
@@ -188,6 +188,7 @@ void print_op (op_desc_t * op_desc)
 
 	if (count >= 1)
 		{
+		if (op_desc->var_wb) printf(op_desc->var_wb == VP_WORD? "WORD ": "BYTE ");
 		print_var (&(op_desc->var_to));
 		}
 


### PR DESCRIPTION
This PR adds more specific operand size to the AT&T and Intel instruction display, only (almost) for those instructions where the operation would otherwise be ambiguous. 

Finalizes #9 and discussed in https://github.com/mfld-fr/emu86/pull/8#issuecomment-713423167.

This was a bit more tricky than I thought, since I wanted to keep the clean look that EMU86 currently has for instruction decoded in both AT&T and Intel display, and not add a byte/word suffix unless necessary. Some instructions (those in the OP_CALC2 range) will always display their byte/word size in the instruction since their operand size is not encoded separately from the instruction W bit. (Only the immediate size is encoded seperately).

Tested running ELKS in EMU86, but with a limited set of instructions for the time being, since ELKS remains in a tight loop halted in the idle task, and then interrupted by the timer. Thus, there may be a few more instructions whose operand display needs to be slightly tweaked, when they are found in the future.


