### PR TITLE
Fix console raw mode with usage() and abort() calls

### DIFF
--- a/emu-console.c
+++ b/emu-console.c
@@ -81,15 +81,22 @@ void serial_normal ()
 	tcsetattr(0, TCSANOW, &def_termios);
 	}
 
+static void catch_abort(int sig)
+	{
+	exit(1);
+	}
+
 void serial_init ()
 	{
 	tcgetattr(0, &def_termios);
 	signal(SIGINT, serial_catch);
 	serial_raw();
+	signal(SIGABRT, catch_abort);
+	atexit(serial_term);
 	}
 
 
 void serial_term ()
 	{
-	serial_normal();
+	if (def_termios.c_oflag) serial_normal();
 	}


### PR DESCRIPTION
Fixes tty left in raw mode from discussion in https://github.com/mfld-fr/emu86/issues/12#issuecomment-715394055.
