### PR TITLE
Fix console when serial_recv called with no input ready

### DIFF
--- a/emu-console.c
+++ b/emu-console.c
@@ -20,7 +20,7 @@ void serial_send (byte_t c)
 	int n = write (1, &c, 1);
 	if (n != 1)
 		{
-		perror ("warning: cannot write to console:");  // TODO: propagate error
+		perror ("warning: cannot write to console");  // TODO: propagate error
 		}
 	}
 
@@ -29,11 +29,20 @@ byte_t serial_recv ()
 	{
 	byte_t c = 0xFF;
 
+	if (!serial_poll())
+		{
+		fd_set fdsr;
+		FD_ZERO (&fdsr);
+		FD_SET (0, &fdsr);
+		int s = select (1, &fdsr, NULL, NULL, NULL);
+		if (s < 0)
+			return -1;		// required for updated source when ^C hit on read
+		}
 	int n = read (0, &c, 1);
 	if (n == 0) return 0;
 	if (n != 1)
 		{
-		perror ("warning: cannot read from console:");  // TODO: propagate error
+		perror ("warning: cannot read from console");  // TODO: propagate error
 		}
 	if (c == 0x7f) c = '\b';	// convert DEL to BS
 


### PR DESCRIPTION
This fixes issue #12.

Problem was verified with emulating INT 16h AH=0 (read kbd). When this was called without a prior INT 16h AH=1 (peek kbd), read would return an errno such that "Resource temporarily not available" is displayed.

Fix checks for character ready before reading.

A further check for a failed select() is added, which returns -EINTR when ^C is typed. This allows EMU86 to regain control when ^C is typed at BIOS read. The -1 return will be required for the updated serial_recv API (which has not been committed yet), but this version works in both cases, returning 0xFF in this version and -1 in the future.

@mfld-fr : Please test. I think you will find that the new console driver is superior for using EMU86, compared to the PTY driver, now that this problem has been addressed and fixed. Thank you!