### PR TITLE
Temporary add INT 8 to HLT for ELKS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ EMU86_OBJS += serial-$(SERIAL).o
 
 TARGET=elks
 #TARGET=advtech
+ifeq ($(TARGET), elks)
+CFLAGS += -DELKS
+endif
 
 EMU86_OBJS += \
 	io-$(TARGET).o \

--- a/op-exec.c
+++ b/op-exec.c
@@ -1368,7 +1368,9 @@ static int op_flag_acc (op_desc_t * op_desc)
 static int op_halt (op_desc_t * op_desc)
 	{
 	assert (OP_ID == OP_HLT);
+#ifdef ELKS
 	exec_int (8);  // TEMP HACK
+#endif
 	return 0;
 	}
 

--- a/op-exec.c
+++ b/op-exec.c
@@ -1368,6 +1368,7 @@ static int op_flag_acc (op_desc_t * op_desc)
 static int op_halt (op_desc_t * op_desc)
 	{
 	assert (OP_ID == OP_HLT);
+	exec_int (8);  // TEMP HACK
 	return 0;
 	}
 


### PR DESCRIPTION
Requested in #16. With this modification, ELKS v0.4.0 (CONFIG_ROMCODE) runs on EMU86.

If accepted, I will reference commit in ELKS tools/Makefile, and this can be reverted when the ELKS dummy timer is implemented.

I should have more time shortly, I hope to help move along some of the other EMU86 open issues.

Thanks!