### PR TITLE
Enhancements and fixes to allow booting ELKS disk images using INT 13h

### DIFF
--- a/op-id-name.c
+++ b/op-id-name.c
@@ -64,6 +64,7 @@ static op_id_name_t id_name_tab [] = {
 	{ OP_LOOP,   "LOOP"   },
 	{ OP_LOOPNZ, "LOOPNZ" },
 	{ OP_LOOPZ,  "LOOPZ"  },
+	{ OP_JCXZ,   "JCXZ"   },
 	{ OP_MOV,    "MOV"    },
 	{ OP_MOVS,   "MOVS"   },
 	{ OP_MUL,    "MUL"    },

--- a/op-print-att.c
+++ b/op-print-att.c
@@ -187,7 +187,13 @@ void print_op (op_desc_t * op_desc)
 
 		char * p = name;
 		char * q = name2;
-		while (*p) *q++ = *p++ - 'A' + 'a';
+		while (*p)
+			{
+			if (*p >= 'A')
+				*q++ = *p++ - 'A' + 'a';
+			else
+				*q++ = *p++;
+			}
 
 		// Operation name suffix to explicit operand size
 


### PR DESCRIPTION
This PR greatly improves the usefulness of EMU86, as it can now boot standard ELKS disk images, as well as ROM images.
Completes issue #18 and partially #11.

Adds -I option to specify disk images to be treated as BIOS disk drives on EMU86.
Will boot first -I option, and additional -I options are treated as additional floppy or hard drive devices.
Drive CHS automatically calculated based on image size.
Boots Minix and FAT floppy images, as well as Minix and FAT flat and MBR hard drive images.
Example:
```
emu86 -I elks/image/fd1440.bin -I elks/image/hd32-minix.bin
```
will boot from 1.44M floppy and add additional hard drive as second disk. Up to 4 total floppy or hard drives supported.

Emulator fixes:
Adds RET \<imm16\> opcode support
Fixes MUL and IMUL buggy opcodes
Fixes JCXZ display
Fixes INT3 display

BIOS emulation enhancements:
Adds INT 19h BIOS boot
Adds INT 13h disk services read/write/get_params functions 02h, 03h, 08h
Checks for and prohibits multi-track reads
Adds INT 10h function 12h get EGA
Adds INT 10h function 1Ah get VGA
Adds -v <level> option for setting verbose output info level
Displays disk read/writes on verbose & 1
Displays [INT %xh AX %04X] trace on verbose & 2

Requires changes from https://github.com/jbruchon/elks/pull/880 in order to work, which include BIOS or Headless Console, HLT on idle, CONFIG_IDE_PROBE disabled, and removal of INT 13h function 15h (unused read DASD for Bootlin).

I'm still not completely happy with the trace HW and SW interrupts (#11), as INT 8 timer and BIOS kbd polling pretty much scroll continuously, but the current option helps debugging.

Tested on both targets, requires ELKS target. Almost all commands run, reboot and vi still failing for reasons yet unknown.