### PR TITLE
Fixes for macOS stdio bugs

### DIFF
--- a/emu-main.c
+++ b/emu-main.c
@@ -347,7 +347,6 @@ int main (int argc, char * argv [])
 			if (flag_trace)
 				{
 				// Print processor status
-
 				printf ("%.4hX:%.4hX  ", seg_get (SEG_CS), reg16_get (REG_IP));
 				print_column (op_code_str, 3 * OPCODE_MAX + 1);
 				print_op (&desc);
@@ -365,6 +364,7 @@ int main (int argc, char * argv [])
 				char com [8];
 				if (!flag_trace) putchar ('\n');
 				putchar ('>');
+				fflush(stdout);
 				char * res = fgets (com, 8, stdin);
 				if (!res) break;
 				serial_raw();


### PR DESCRIPTION
Hello @mfld-fr,

This fixes as long-time problem that I finally tracked down in macOS: on long 'c' traces, unbelievably, macOS stdio drops characters, making scroll back inspection of some traced instructions unreadable. This fix sets no buffering for macOS only, and adds the required buffer flushes in order to work properly. Also, the tcsetattr's now wait until output is finished before transitioning between raw/cooked modes.

It's still not perfect - on ^C the system still drops some output, but much better than before.

Thanks!