### PR TITLE
Allow emulation of standard ELKS kernels without reconfiguration

### DIFF
--- a/emu-main.c
+++ b/emu-main.c
@@ -87,6 +87,7 @@ int info_level;
 int main (int argc, char * argv [])
 	{
 	int exit_code = 0;
+	int instr_count = 0;
 
 	while (1)
 		{
@@ -292,6 +293,14 @@ int main (int argc, char * argv [])
 				err = exec_int (vect);
 				assert (!err);
 				}
+
+#ifdef ELKS
+				if (++instr_count > 20000 && flag_get(FLAG_IF) && rep_none() && seg_none())
+					{
+					exec_int (0x08);	// force timer 0 interrupt
+					instr_count = 0;
+					}
+#endif
 
 			// Decode next instruction
 

--- a/io-elks.c
+++ b/io-elks.c
@@ -3,18 +3,38 @@
 // ELKS target
 //-------------------------------------------------------------------------------
 
+#include <stdio.h>
 #include "emu-mem-io.h"
+
+extern int info_level;
 
 //-------------------------------------------------------------------------------
 
 int io_read_byte (word_t p, byte_t * b)
 	{
-	*b = 0xFF;
+	switch (p)
+		{
+		case 0x1F7:		// HD1 status
+		case 0x177:		// HD2 status
+			*b = 0x7f;	// ready, drive not found
+			break;
+		default:
+			*b = 0xFF;
+			break;
+		}
+	if (info_level & 4) printf("[ INB %3xh AL %02xh]\n", p, *b);
 	return 0;
 	}
 
 int io_write_byte (word_t p, byte_t b)
 	{
+	switch (p)
+		{
+		case 0x20:		// 8259 EOI
+			break;
+		default:
+			if (info_level & 4) printf("[OUTB %3xh AL %0xh]\n", p, b);
+		}
 	return 0;
 	}
 
@@ -30,6 +50,7 @@ int io_read_word (word_t p, word_t * w)
 		}
 	else {
 		// no port
+		if (info_level & 4) printf("[ INW %3xh AX %04xh]\n", p, *w);
 		*w = 0xFFFF;
 		err = 0;
 		}
@@ -47,6 +68,7 @@ int io_write_word (word_t p, word_t w)
 		}
 	else {
 		// no port
+		if (info_level & 4) printf("[OUTW %3xh AX %0xh]\n", p, w);
 		err = 0;
 		}
 

--- a/op-exec.c
+++ b/op-exec.c
@@ -1378,9 +1378,6 @@ static int op_flag_acc (op_desc_t * op_desc)
 static int op_halt (op_desc_t * op_desc)
 	{
 	assert (OP_ID == OP_HLT);
-#ifdef ELKS
-	exec_int (8);  // TEMP HACK
-#endif
 	return 0;
 	}
 


### PR DESCRIPTION
This PR allows `emu86` to boot and run ELKS kernels built for IBM PCs without modification.

Changes handling of two items that previously required building a special image in order to run:
- Removes temporary INT 8 on HLT instruction.
- Adds (temporary) INT 8 every 20,000 instructions. (\#ifdef ELKS only).
- Adds special handling for INB instruction from ports 0x1F7 and 0x177 (HD1/HD2 status registers). The CONFIG_IDE_PROBE option, default ON, busy-loops waiting for bit 7 to be 0, which otherwise hangs the boot.

Also adds IN/OUT port display using verbose info level 4 (-v4). This will display all I/O using IN/INB/OUT/OUTB instructions, except for the 8259 EOI.
