### PR TITLE
Refactor main loop

### DIFF
--- a/char-stdio.c
+++ b/char-stdio.c
@@ -71,9 +71,9 @@ int char_poll ()
 
 void catch_int ()
 {
-	extern int flag_prompt;
-
-	flag_prompt = 1;
+	extern int _flag_prompt;
+	// FIXME: SIGINT should be hooked in main()
+	_flag_prompt = 1;
 }
 
 

--- a/emu-main.c
+++ b/emu-main.c
@@ -92,45 +92,150 @@ static int file_load (addr_t start, char * path)
 	}
 
 
-// Main loop
+//------------------------------------------------------------------------------
+// Debug procedure
+//------------------------------------------------------------------------------
 
-int flag_prompt = 0;
-int info_level = 0;
-static int flag_trace = 0;
-static int flag_exit = 0;
-static addr_t break_code_addr = -1;
+static op_desc_t _op_desc;
 
-void main_loop(void)
+static addr_t _break_code_addr = -1;
+
+static int _flag_trace  = 0;  // trace next instruction
+// FIXME: used by signal handler in character backend
+/*static*/ int _flag_prompt = 0;  // prompt for debug command
+static int _flag_exec   = 1;  // execute next instruction
+static int _flag_exit   = 0;  // exit main loop
+
+
+static int debug_proc ()
 	{
-	static op_desc_t desc;
+	int err = 0;
+
+	while (1)
+		{
+		if (_flag_trace)
+			{
+			// Print next instruction before execution
+
+			printf ("%.4hX:%.4hX  ", seg_get (SEG_CS), reg16_get (REG_IP));
+			print_column (op_code_str, 3 * OPCODE_MAX + 1);
+			print_op (&_op_desc);
+			putchar ('\n');
+			}
+
+		if (_flag_prompt)
+			{
+			// Get user command
+			// FIXME: use safer input function
+
+			con_normal();
+			char command [8];
+			if (!_flag_trace) putchar ('\n');
+			putchar ('>');
+			fflush(stdout);
+			char * res = fgets (command, 8, stdin);
+			if (!res) {
+				err = -1;
+				break;
+				}
+
+			con_raw();
+
+			switch (command [0])
+				{
+				// Dump stack
+
+				case 's':
+					stack_print ();
+					_flag_trace = 0;
+					_flag_exec = 0;
+					break;
+
+				// Print registers
+
+				case 'r':
+					regs_print ();
+					_flag_trace = 0;
+					_flag_exec = 0;
+					break;
+
+				// Step over
+
+				case 'p':
+					_break_code_addr = addr_seg_off (op_code_seg, op_code_off);
+					_flag_trace = 0;
+					_flag_prompt = 0;
+					break;
+
+				// Trace one step
+
+				case 't':
+				case '\n':
+					_flag_trace = 1;
+					_flag_prompt = 1;
+					break;
+
+				// Continue tracing
+
+				case 'c':
+					_flag_trace = 1;
+					_flag_prompt = 0;
+					break;
+
+				// Go (keep breakpoints)
+
+				case 'g':
+					_flag_trace = 0;
+					_flag_prompt = 0;
+					break;
+
+				// Quit
+
+				case 'q':
+					_flag_exec = 0;
+					_flag_exit = 1;
+					break;
+
+				// Interrupt (only timer for now)
+
+				case 'i':
+					_flag_exec = 0;
+					err = exec_int (0x08);  // timer 0 interrupt
+					if (err) puts ("error: timer interrupt");
+					break;
+
+				}  // command switch
+			}  // _flag_prompt
+
+		break;
+		}
+
+	return err;
+	}
+
+
+//------------------------------------------------------------------------------
+// Main loop
+//------------------------------------------------------------------------------
+
+int info_level = 0;
+
+static void main_loop (void)
+	{
 	static word_t last_seg = 0xFFFF;
 	static word_t last_off_0 = 0xFFFF;
 	static word_t last_off_1;
 
-	if (flag_exit)
-		{
-		// Cleanup
-#ifdef ELKS
-		image_close ();
-#endif
-		con_term ();
-		serial_term ();
-
-		exit(0);
-		}
-
 		// Main loop
 			{
-			int flag_exec = 1;
-
 			// Animate emulated devices
 
 			timer_proc ();
 
 			int err = serial_proc ();
 			if (err) {
-				flag_exec = 0;
-				flag_exit = 1;
+				_flag_exec = 0;
+				_flag_exit = 1;
 				return;
 				}
 
@@ -152,11 +257,11 @@ void main_loop(void)
 
 			// Code breakpoint test
 
-			if (addr_seg_off (op_code_seg, op_code_off) == break_code_addr)
+			if (addr_seg_off (op_code_seg, op_code_off) == _break_code_addr)
 				{
 				puts ("info: code breakpoint hit");
-				flag_trace = 1;
-				flag_prompt = 1;
+				_flag_trace = 1;
+				_flag_prompt = 1;
 				}
 
 			// Optimize: no twice decoding of the same instruction
@@ -167,15 +272,15 @@ void main_loop(void)
 				last_seg = op_code_seg;
 				last_off_0 = op_code_off;
 
-				memset (&desc, 0, sizeof desc);
+				memset (&_op_desc, 0, sizeof _op_desc);
 
-				err = op_decode (&desc);
+				err = op_decode (&_op_desc);
 				if (err)
 					{
 					puts ("\nerror: unknown opcode");
-					flag_trace = 1;
-					flag_prompt = 1;
-					flag_exec = 0;
+					_flag_trace = 1;
+					_flag_prompt = 1;
+					_flag_exec = 0;
 					}
 
 				// Suspicious operation on null opcodes
@@ -185,9 +290,9 @@ void main_loop(void)
 					puts ("\nerror: suspicious null opcodes");
 
 					op_code_null = 0;
-					flag_trace = 1;
-					flag_prompt = 1;
-					flag_exec = 0;
+					_flag_trace = 1;
+					_flag_prompt = 1;
+					_flag_exec = 0;
 					}
 
 				last_off_1 = op_code_off;
@@ -197,115 +302,26 @@ void main_loop(void)
 				op_code_off = last_off_1;
 				}
 
-			if (flag_trace)
-				{
-				// Print processor status
-				printf ("%.4hX:%.4hX  ", seg_get (SEG_CS), reg16_get (REG_IP));
-				print_column (op_code_str, 3 * OPCODE_MAX + 1);
-				print_op (&desc);
-				putchar ('\n');
-				}
+			// Debug procedure
+			// After decoding the next instruction
+			// Before executing that instruction
 
-			// User prompt
-
-			if (flag_prompt)
-				{
-				// Get user command
-				// Ugly but temporary
-
-#if SDL
-printf("exiting at prompt\n");
-exit(1);
-#endif
-				con_normal();
-				char com [8];
-				if (!flag_trace) putchar ('\n');
-				putchar ('>');
-				fflush(stdout);
-				char * res = fgets (com, 8, stdin);
-				if (!res) return;
-				con_raw();
-
-				switch (com [0])
-					{
-					// Dump stack
-
-					case 's':
-						stack_print ();
-						flag_trace = 0;
-						flag_exec = 0;
-						break;
-
-					// Print registers
-
-					case 'r':
-						regs_print ();
-						flag_trace = 0;
-						flag_exec = 0;
-						break;
-
-					// Step over
-
-					case 'p':
-						break_code_addr = addr_seg_off (op_code_seg, op_code_off);
-						flag_trace = 0;
-						flag_prompt = 0;
-						break;
-
-					// Trace one step
-
-					case 't':
-					case '\n':
-						flag_trace = 1;
-						flag_prompt = 1;
-						break;
-
-					// Continue tracing
-
-					case 'c':
-						flag_trace = 1;
-						flag_prompt = 0;
-						break;
-
-					// Go (keep breakpoints)
-
-					case 'g':
-						flag_trace = 0;
-						flag_prompt = 0;
-						break;
-
-					// Quit
-
-					case 'q':
-						flag_exec = 0;
-						flag_exit = 1;
-						break;
-
-					// Interrupt (only timer for now)
-
-					case 'i':
-						flag_exec = 0;
-						err = exec_int (0x08);  // timer 0 interrupt
-						if (err) puts ("error: timer interrupt");
-						break;
-
-					}
-				}
+			err = debug_proc ();
 
 			// Execute operation
 
-			if (flag_exec)
+			if (_flag_exec)
 				{
 				int trace_before = flag_get (FLAG_TF);
 
 				reg16_set (REG_IP, op_code_off);
 
-				err = op_exec (&desc);
+				err = op_exec (&_op_desc);
 				if (err)
 					{
 					puts (err < 0 ? "error: execute operation" : "warning: paused (HLT)");
-					flag_trace = 1;
-					flag_prompt = 1;
+					_flag_trace = 1;
+					_flag_prompt = 1;
 					if (err < 0) reg16_set (REG_IP, last_off_0);
 					}
 				else
@@ -329,20 +345,21 @@ exit(1);
 						if (err)
 							{
 							puts ("fatal: trace interrupt");
-							flag_exit = 1;
+							_flag_exit = 1;
 							}
 						}
 					}
 				}
 
 			// Data breakpoint test
+			// FIXME: break before executing data access
 
 			if (_break_data_flag)
 				{
 				puts ("info: data breakpoint hit");
 				_break_data_flag = 0;
-				flag_trace = 1;
-				flag_prompt = 1;
+				_flag_trace = 1;
+				_flag_prompt = 1;
 				}
 
 			// INT3 breakpoint test
@@ -351,16 +368,181 @@ exit(1);
 				{
 				puts ("info: INT3 breakpoint hit");
 				_break_int_flag = 0;
-				flag_trace = 1;
-				flag_prompt = 1;
+				_flag_trace = 1;
+				_flag_prompt = 1;
 				}
 			}
 	}
 
+
+//------------------------------------------------------------------------------
+// Command line
+//------------------------------------------------------------------------------
+
+static void usage (char * argv0)
+	{
+	printf ("usage: %s [options]\n\n", argv0);
+	puts ("  -w <address>         load address");
+	puts ("  -f <path>            file path");
+	puts ("  -I <path>            disk image path");
+	puts ("  -x <segment:offset>  execute address");
+	puts ("  -c <address>         code breakpoint address");
+	puts ("  -d <address>         data breakpoint address");
+	puts ("  -t                   trace mode");
+	puts ("  -i                   interactive mode");
+	puts ("  -p                   program mode");
+	puts ("  -v <level>           verbose info level");
+	}
+
+
+int command_line (int argc, char * argv [])
+	{
+	int err = 0;
+
+	char opt;
+	int file_loaded = 0;
+	addr_t file_address = -1;
+	char * file_path = NULL;
+	char * disk_image_path = NULL;
+
+	while (1)
+		{
+		opt = getopt (argc, argv, "w:f:I:x:c:d:v:tip");
+		if (opt < 0 || opt == '?') break;
+
+		switch (opt)
+			{
+			case 'w':  // load address
+				if (sscanf (optarg, "%lx", &file_address) != 1)
+					{
+					puts ("error: bad load address");
+					}
+				else
+					{
+					printf ("info: load address %.5lXh\n", file_address);
+					}
+
+				break;
+
+			case 'f':  // file path
+				file_path = optarg;
+				printf ("info: load file %s\n", file_path);
+				break;
+
+			case 'I':  // disk image file path
+				disk_image_path = optarg;
+				break;
+
+			// Execution address:
+			// used to override the default CS:IP at reset
+
+			case 'x':  // execute address
+				if (sscanf (optarg, "%hx:%hx", &op_code_seg, &op_code_off) != 2)
+					{
+					puts ("error: bad execute address");
+					}
+				else
+					{
+					printf ("info: execute address %.4hXh:%.4hXh\n", op_code_seg, op_code_off);
+
+					seg_set (SEG_CS, op_code_seg);
+					reg16_set (REG_IP, op_code_off);
+					}
+
+				break;
+
+			case 'c':  // code breakpoint address
+				if (sscanf (optarg, "%lx", &_break_code_addr) != 1)
+					{
+					puts ("error: bad code breakpoint address");
+					}
+				else
+					{
+					printf ("info: code breakpoint address %.5lXh\n", _break_code_addr);
+					}
+
+				break;
+
+			case 'd':  // data breakpoint address
+				if (sscanf (optarg, "%lx", &_break_data_addr) != 1)
+					{
+					puts ("error: bad data breakpoint address");
+					}
+				else
+					{
+					printf ("info: data breakpoint address %.5lXh\n", _break_data_addr);
+					}
+
+				break;
+
+			case 't':  // trace mode
+				_flag_trace = 1;
+				break;
+
+			case 'i':  // interactive mode
+				_flag_trace = 1;
+				_flag_prompt = 1;
+				break;
+
+			case 'v':  // verbose output level
+				info_level = atoi(optarg);
+				break;
+
+			// Program mode:
+			// used when running a stand-alone executable
+			// in the tiny memory model where CS=DS=ES=SS
+
+			case 'p':
+				seg_set (SEG_DS, seg_get (SEG_CS));
+				seg_set (SEG_ES, seg_get (SEG_CS));
+				seg_set (SEG_SS, seg_get (SEG_CS));
+				break;
+
+			}  // option switch
+
+		if (file_address != -1 && file_path)
+			{
+			if (!file_load (file_address, file_path))
+				{
+				file_loaded = 1;
+				}
+
+			file_path = NULL;
+			file_address = -1;
+			}
+
+#ifdef ELKS
+		if (disk_image_path)
+			{
+			if (!image_load (disk_image_path))
+				{
+				file_loaded = 1;
+				}
+
+			disk_image_path = NULL;
+			}
+#endif
+
+		}  // option loop
+
+	if (opt == '?' || optind != argc || !file_loaded)
+		{
+		usage (argv [0]);
+		err = -1;
+		}
+
+	return err;
+	}
+
+
+//------------------------------------------------------------------------------
 // Program main
+//------------------------------------------------------------------------------
 
 int main (int argc, char * argv [])
 	{
+	int err = 0;
+
 #ifdef __EMSCRIPTEN__
 	static char *av[] = { 0, "-w", "0xe0000", "-f", "Image", "-w", "0x80000", "-f", "romfs.bin", 0};
 	argc = sizeof(av) / sizeof(av[1]) - 1;
@@ -372,157 +554,18 @@ int main (int argc, char * argv [])
 		mem_io_reset ();
 		proc_reset ();
 
-		char * file_path = NULL;
-		char * disk_image_path = NULL;
-		addr_t file_address = -1;
-		int file_loaded = 0;
-
 		// Auto check
 
-		int err = check_exec ();
-		if (err)
-			{
+		err = check_exec ();
+		if (err) {
 			puts ("fatal: auto check");
-			exit(-1);
+			break;
 			}
 
 		// Process command line
 
-		char opt;
-
-		while (1)
-			{
-			opt = getopt (argc, argv, "w:f:I:x:c:d:v:tip");
-			if (opt < 0 || opt == '?') break;
-
-			switch (opt)
-				{
-				case 'w':  // load address
-					if (sscanf (optarg, "%lx", &file_address) != 1)
-						{
-						puts ("error: bad load address");
-						}
-					else
-						{
-						printf ("info: load address %.5lXh\n", file_address);
-						}
-
-					break;
-
-				case 'f':  // file path
-					file_path = optarg;
-					printf ("info: load file %s\n", file_path);
-					break;
-
-				case 'I':  // disk image file path
-					disk_image_path = optarg;
-					break;
-
-				// Execution address:
-				// used to override the default CS:IP at reset
-
-				case 'x':  // execute address
-					if (sscanf (optarg, "%hx:%hx", &op_code_seg, &op_code_off) != 2)
-						{
-						puts ("error: bad execute address");
-						}
-					else
-						{
-						printf ("info: execute address %.4hXh:%.4hXh\n", op_code_seg, op_code_off);
-
-						seg_set (SEG_CS, op_code_seg);
-						reg16_set (REG_IP, op_code_off);
-						}
-
-					break;
-
-				case 'c':  // code breakpoint address
-					if (sscanf (optarg, "%lx", &break_code_addr) != 1)
-						{
-						puts ("error: bad code breakpoint address");
-						}
-					else
-						{
-						printf ("info: code breakpoint address %.5lXh\n", break_code_addr);
-						}
-
-					break;
-
-				case 'd':  // data breakpoint address
-					if (sscanf (optarg, "%lx", &_break_data_addr) != 1)
-						{
-						puts ("error: bad data breakpoint address");
-						}
-					else
-						{
-						printf ("info: data breakpoint address %.5lXh\n", _break_data_addr);
-						}
-
-					break;
-
-				case 't':  // trace mode
-					flag_trace = 1;
-					break;
-
-				case 'i':  // interactive mode
-					flag_trace = 1;
-					flag_prompt = 1;
-					break;
-
-				case 'v':  // verbose output level
-					info_level = atoi(optarg);
-					break;
-
-				// Program mode:
-				// used when running a stand-alone executable
-				// in the tiny memory model where CS=DS=ES=SS
-
-				case 'p':
-					seg_set (SEG_DS, seg_get (SEG_CS));
-					seg_set (SEG_ES, seg_get (SEG_CS));
-					seg_set (SEG_SS, seg_get (SEG_CS));
-					break;
-
-				}
-
-			if (file_address != -1 && file_path)
-				{
-				if (!file_load (file_address, file_path))
-					{
-					file_loaded = 1;
-					}
-
-				file_path = NULL;
-				file_address = -1;
-				}
-#ifdef ELKS
-			if (disk_image_path)
-				{
-				if (!image_load (disk_image_path))
-					{
-					file_loaded = 1;
-					}
-
-				disk_image_path = NULL;
-				}
-#endif
-			}
-
-		if (opt == '?' || optind != argc || !file_loaded)
-			{
-			printf ("usage: %s [options]\n\n", argv [0]);
-			puts ("  -w <address>         load address");
-			puts ("  -f <path>            file path");
-			puts ("  -I <path>            disk image path");
-			puts ("  -x <segment:offset>  execute address");
-			puts ("  -c <address>         code breakpoint address");
-			puts ("  -d <address>         data breakpoint address");
-			puts ("  -t                   trace mode");
-			puts ("  -i                   interactive mode");
-			puts ("  -p                   program mode");
-			puts ("  -v <level>           verbose info level");
-			exit(1);
-			}
+		err = command_line (argc, argv);
+		if (err) break;
 
 		rom_init ();     // ROM stub initialization
 		int_init ();     // PIC initialization
@@ -530,22 +573,45 @@ int main (int argc, char * argv [])
 		serial_init ();  // Serial port initialization
 		con_init ();     // Console initialization
 
+		op_code_base = mem_get_addr (0);
+
+		while (!_flag_exit)
+			{
+			main_loop();
+
+#ifdef __EMSCRIPTEN__
+
+			if (++mainloop_count >= MAINLOOP_TIMER)
+				{
+				// Actually an asynchronous function
+				// https://github.com/mfld-fr/emu86/issues/32#issuecomment-830690460
+
+				// Unwind the stack and return to browser
+				emscripten_sleep(1);
+				// Browser called back and stack was rewinded
+
+				mainloop_count = 0;
+				}
+#endif
+			}
+
 		break;
 		}
 
-	op_code_base = mem_get_addr (0);
+	// Cleanup
 
-	while (1)
-		{
-		main_loop();
-#ifdef __EMSCRIPTEN__
-		if (++mainloop_count >= MAINLOOP_TIMER)
-			{
-			emscripten_sleep(1);
-			mainloop_count = 0;
-			}
+#ifdef ELKS
+	// FIXME: move to rom_term()
+	image_close ();
 #endif
-		}
 
-	return 0;
+	con_term ();
+	serial_term ();
+
+	// Asked by @ghaer in https://github.com/mfld-fr/emu86/pull/37#issuecomment-830708810
+	// Because there are still some exit() in the code path
+	//return (err >= 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	_exit ((err >= 0) ? EXIT_SUCCESS : EXIT_FAILURE);
 	}
+
+//------------------------------------------------------------------------------


### PR DESCRIPTION
Tried to make the main loop more readable:
- debug procedure moved out
- command line processing moved out
- avoid breaking the program path with `exit()`
