### PR TITLE
Fix Control-C Linux terminal exit

### DIFF
--- a/char-stdio.c
+++ b/char-stdio.c
@@ -83,8 +83,8 @@ void char_raw ()
 	fflush(stdout);
 	tcgetattr(0, &termios);
 	termios.c_iflag &= ~(ICRNL|IGNCR|INLCR);
-	//termios.c_oflag &= ~(OPOST);
 	termios.c_lflag &= ~(ECHO|ECHOE|ECHONL|ICANON);
+	termios.c_lflag |= ISIG;
 	tcsetattr(0, TCSADRAIN, &termios);
 
 	int nonblock = 1;

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -255,7 +255,7 @@ int image_load (char * path)
 void image_close (void)
 		{
 		struct diskinfo *dp;
-		for (dp = diskinfo; dp <= &diskinfo[sizeof(diskinfo)/sizeof(diskinfo[0])]; dp++)
+		for (dp = diskinfo; dp < &diskinfo[sizeof(diskinfo)/sizeof(diskinfo[0])]; dp++)
 			{
 			if (dp->fd != -1)
 				close (dp->fd);


### PR DESCRIPTION
Fixes #31.

`image_close` had an off-by-one that ended up closing stdin, dependent on the linker layout of the data section.

Also ensures ^C signals can be processed by setting ISIG.