### PR TITLE
Tune SDL and Emscripten/browser platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ Two default configurations are provided for convenience:
 
 Then run `make clean` and `make` as usual.
 
+To build and run browser version (requires ELKS):
+* Goto https://emscripten.org/docs/getting_started/downloads.html to download and install Emscripten SDK.
+* Change PLATFORM=emscripten in config.mk
+* `source ~/emsdk/emsdk_env.sh`
+* `make`
+* `emrun --serve_after_close emu86.html`
+
 
 ## TO DO LIST
 

--- a/elks.sh
+++ b/elks.sh
@@ -2,4 +2,10 @@
 
 # Run ELKS previously built in EMU86 configuration (see elks/emu86.sh)
 
-./emu86 -w 0xe0000 -f ../elks-upstream/elks/arch/i86/boot/Image -w 0x80000 -f ../elks-upstream/image/romfs.bin $@
+exec ./emu86 -w 0xe0000 -f ../elks-upstream/elks/arch/i86/boot/Image -w 0x80000 -f ../elks-upstream/image/romfs.bin $@
+
+# Run ELKS in browser (set PLATFORM=emscripten in config.mk and rebuild EMU86):
+# source ~/emsdk/emsdk_env.sh
+# make
+
+exec emrun --serve_after_close emu86.html -- -v3 -w 0x10000 -x 0x1000:0x34 -f emu-main.c

--- a/emu-main.c
+++ b/emu-main.c
@@ -25,11 +25,6 @@
 #include <emscripten.h>
 #define MAINLOOP_TIMER 2000
 int mainloop_count = 0;
-#define INST_TIMER	1500
-#elif SDL
-#define INST_TIMER	3000
-#else
-#define INST_TIMER	20000
 #endif
 
 extern int image_load (char * path);

--- a/timer-elks.c
+++ b/timer-elks.c
@@ -7,7 +7,13 @@
 
 #include "int-elks.h"
 
+#ifdef __EMSCRIPTEN__
+#define TIMER_MAX 1500
+#elif SDL
+#define TIMER_MAX 3000
+#else
 #define TIMER_MAX 20000
+#endif
 
 static int timer_count = 0;
 


### PR DESCRIPTION
The terminal, SDL and Emscripten platforms each require slightly different timer countdowns for fastest operation.

Also adds some instructions for how to build and run the Emscripten version.