### PR TITLE
Add support for ELKS BIOS console

### DIFF
--- a/con-char.c
+++ b/con-char.c
@@ -20,7 +20,6 @@ int con_pos_set (byte_t row, byte_t col)
 
 	if (col == 0 && col_prev != 0)
 		{
-		// char_send (13);  // CR
 		char_send (10);  // LF
 		}
 
@@ -28,6 +27,16 @@ int con_pos_set (byte_t row, byte_t col)
 	return 0;
 	}
 
+int con_pos_get (byte_t *row, byte_t *col)
+	{
+	*row = *col = 0;
+	return 0;
+	}
+
+int con_scrollup ()
+	{
+	return 0;
+	}
 
 int con_get_key (word_t * k)
 	{

--- a/con-char.c
+++ b/con-char.c
@@ -52,6 +52,10 @@ int con_poll_key ()
 	return char_poll ();
 	}
 
+int con_update ()
+	{
+	return 0;
+	}
 
 void con_raw ()
 	{

--- a/con-none.c
+++ b/con-none.c
@@ -15,6 +15,17 @@ int con_pos_set (byte_t row, byte_t col)
 	return 0;
 	}
 
+int con_pos_get (byte_t *row, byte_t *col)
+	{
+	*row = *col = 0;
+	return 0;
+	}
+
+int con_scrollup ()
+	{
+	return 0;
+	}
+
 int con_get_key (word_t * k)
 	{
 	*k = 0;

--- a/con-none.c
+++ b/con-none.c
@@ -37,6 +37,11 @@ int con_poll_key ()
 	return 0;
 	}
 
+int con_update ()
+	{
+	return 0;
+	}
+
 void con_raw ()
 	{
 	}

--- a/con-sdl.c
+++ b/con-sdl.c
@@ -231,7 +231,6 @@ void sdl_draw(int x, int y, int width, int height)
 	r.w = width? width: WIDTH;
 	r.h = height? height: HEIGHT;
 
-printf("DRAW\n");
 	unsigned char *pixels = screen + y * PITCH + x * (BPP >> 3);
 	SDL_UpdateTexture(sdlTexture, &r, pixels, PITCH);
 

--- a/config.mk
+++ b/config.mk
@@ -12,7 +12,7 @@ TARGET=elks
 # emscripten: run in web browser
 
 PLATFORM=terminal
-#PLATFORM=emscripten
+PLATFORM=emscripten
 
 # Console backend
 # none:  no console backend

--- a/config.mk
+++ b/config.mk
@@ -12,7 +12,7 @@ TARGET=elks
 # emscripten: run in web browser
 
 PLATFORM=terminal
-PLATFORM=emscripten
+#PLATFORM=emscripten
 
 # Console backend
 # none:  no console backend

--- a/emu-con.h
+++ b/emu-con.h
@@ -13,6 +13,7 @@ int con_scrollup ();
 
 int con_get_key (word_t * k);
 int con_poll_key ();
+int con_update ();
 
 void con_normal ();
 void con_raw ();

--- a/emu-con.h
+++ b/emu-con.h
@@ -8,6 +8,8 @@
 
 int con_put_char (byte_t c);
 int con_pos_set (byte_t row, byte_t col);
+int con_pos_get (byte_t *row, byte_t *col);
+int con_scrollup ();
 
 int con_get_key (word_t * k);
 int con_poll_key ();

--- a/emu-main.c
+++ b/emu-main.c
@@ -23,9 +23,9 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
-#define MAINLOOP_TIMER 2000
-int mainloop_count = 0;
 #endif
+#define MAINLOOP_TIMER 10000
+static int mainloop_count = 0;
 
 extern int image_load (char * path);
 extern void image_close (void);
@@ -574,10 +574,13 @@ int main (int argc, char * argv [])
 			{
 			main_loop();
 
-#ifdef __EMSCRIPTEN__
-
 			if (++mainloop_count >= MAINLOOP_TIMER)
 				{
+				if (con_update())
+					_flag_exit = 1;
+
+#ifdef __EMSCRIPTEN__
+
 				// Actually an asynchronous function
 				// https://github.com/mfld-fr/emu86/issues/32#issuecomment-830690460
 
@@ -585,9 +588,10 @@ int main (int argc, char * argv [])
 				emscripten_sleep(1);
 				// Browser called back and stack was rewinded
 
+#endif
+
 				mainloop_count = 0;
 				}
-#endif
 			}
 
 		break;
@@ -603,7 +607,7 @@ int main (int argc, char * argv [])
 	con_term ();
 	serial_term ();
 
-	// Asked by @ghaer in https://github.com/mfld-fr/emu86/pull/37#issuecomment-830708810
+	// Asked by @ghaerr in https://github.com/mfld-fr/emu86/pull/37#issuecomment-830708810
 	// Because there are still some exit() in the code path
 	//return (err >= 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 	_exit ((err >= 0) ? EXIT_SUCCESS : EXIT_FAILURE);

--- a/io-elks.c
+++ b/io-elks.c
@@ -8,6 +8,7 @@
 #include "int-elks.h"
 
 extern int info_level;
+extern int timer_enabled;
 
 //-------------------------------------------------------------------------------
 
@@ -34,6 +35,12 @@ int io_write_byte (word_t p, byte_t b)
 		case 0x20:  // 8259 PIC
 			int_io_write (p - 0x20, b);
 			break;
+
+		case 0x43: // 8253 timer
+			timer_enabled = 0;
+			if (b == 0x34)
+				timer_enabled = 1; // timer 0, binary count, mode 2
+			/* fall through*/
 
 		default:
 			if (info_level & 4) printf("[OUTB %3xh AL %0xh]\n", p, b);

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -82,7 +82,7 @@ static int int_10h ()
 		// Page ignored in video mode 7
 
 		case 0x0E:
-printf("%c", reg8_get(REG_AL));
+//printf("%c", reg8_get(REG_AL));
 			con_put_char (reg8_get (REG_AL));
 			break;
 

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -82,7 +82,6 @@ static int int_10h ()
 		// Page ignored in video mode 7
 
 		case 0x0E:
-//printf("%c", reg8_get(REG_AL));
 			con_put_char (reg8_get (REG_AL));
 			break;
 

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -41,6 +41,7 @@ static int int_10h ()
 	byte_t r;  // row
 	byte_t c;  // column
 
+//printf("INT 10h fn %x\n", ah);
 	switch (ah)
 		{
 		// Set cursor position
@@ -54,8 +55,9 @@ static int int_10h ()
 		// Get cursor position
 
 		case 0x03:
+			con_pos_get(&r, &c);
+			reg16_set (REG_DX, (r << 8) | c);
 			reg16_set (REG_CX, 0);  // null cursor
-			reg16_set (REG_DX, 0);  // upper-left corner (0,0)
 			break;
 
 		// Select active page
@@ -66,6 +68,7 @@ static int int_10h ()
 		// Scroll up
 
 		case 0x06:
+			con_scrollup();			// ignores row/col numbers
 			break;
 
 		// Write character at current cursor position
@@ -79,6 +82,7 @@ static int int_10h ()
 		// Page ignored in video mode 7
 
 		case 0x0E:
+printf("%c", reg8_get(REG_AL));
 			con_put_char (reg8_get (REG_AL));
 			break;
 

--- a/timer-elks.c
+++ b/timer-elks.c
@@ -7,15 +7,7 @@
 
 #include "int-elks.h"
 
-#ifdef __EMSCRIPTEN__
-#define TIMER_MAX 1500
-//#define TIMER_MAX 20000		// required for BIOS console
-#elif SDL
-#define TIMER_MAX 3000			// OK for emu86-rom.config only
-//#define TIMER_MAX 20000		// required for BIOS console
-#else
-#define TIMER_MAX 20000
-#endif
+#define TIMER_MAX 3000
 
 static int timer_count = 0;
 

--- a/timer-elks.c
+++ b/timer-elks.c
@@ -9,12 +9,12 @@
 
 #define TIMER_MAX 3000
 
+int timer_enabled = 0;
 static int timer_count = 0;
 
 void timer_proc ()
 	{
-	timer_count++;
-	if (timer_count >= TIMER_MAX)
+	if (timer_enabled && ++timer_count >= TIMER_MAX)
 		{
 		int_line_set (INT_LINE_TIMER, 1);
 		timer_count = 0;

--- a/timer-elks.c
+++ b/timer-elks.c
@@ -9,8 +9,10 @@
 
 #ifdef __EMSCRIPTEN__
 #define TIMER_MAX 1500
+//#define TIMER_MAX 20000		// required for BIOS console
 #elif SDL
-#define TIMER_MAX 3000
+#define TIMER_MAX 3000			// OK for emu86-rom.config only
+//#define TIMER_MAX 20000		// required for BIOS console
 #else
 #define TIMER_MAX 20000
 #endif


### PR DESCRIPTION
This PR still contains some debugging statements useful for reproducing #41. They will be removed before merge.

Adds BIOS cursor position and scroll capabilities for ELKS; used by SDL and Emscripten backends to properly emulate ELKS when compiled with BIOS console.