### PR TITLE
Cleanup ELKS specific code

### DIFF
--- a/emu-int.h
+++ b/emu-int.h
@@ -51,3 +51,5 @@ void int_init (void);
 
 // TODO: move to rom-xxx
 void rom_init (void);
+void rom_term (void);
+int rom_image_load (char *path);

--- a/emu-main.c
+++ b/emu-main.c
@@ -506,17 +506,15 @@ int command_line (int argc, char * argv [])
 			file_address = -1;
 			}
 
-#ifdef ELKS
 		if (disk_image_path)
 			{
-			if (!image_load (disk_image_path))
+			if (!rom_image_load (disk_image_path))
 				{
 				file_loaded = 1;
 				}
 
 			disk_image_path = NULL;
 			}
-#endif
 
 		}  // option loop
 
@@ -599,11 +597,7 @@ int main (int argc, char * argv [])
 
 	// Cleanup
 
-#ifdef ELKS
-	// FIXME: move to rom_term()
-	image_close ();
-#endif
-
+	rom_term ();
 	con_term ();
 	serial_term ();
 

--- a/rom-advtech.c
+++ b/rom-advtech.c
@@ -149,3 +149,12 @@ int_num_hand_t _int_tab [] = {
 void rom_init (void)
 	{
 	}
+
+int rom_image_load (char * path)
+	{
+	return 1;	// error
+	}
+
+void rom_term (void)
+	{
+	}

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -189,7 +189,7 @@ static struct diskinfo * find_drive (byte_t drive)
 	}
 
 
-int image_load (char * path)
+int rom_image_load (char * path)
 	{
 	byte_t d = 0, h, s;
 	word_t c;
@@ -255,7 +255,7 @@ int image_load (char * path)
 		return 1;
 	}
 
-void image_close (void)
+void rom_term (void)
 		{
 		struct diskinfo *dp;
 		for (dp = diskinfo; dp < &diskinfo[sizeof(diskinfo)/sizeof(diskinfo[0])]; dp++)


### PR DESCRIPTION
Removes \#ifdef ELKS, cleans up emu-main.c.

Moves rom image handling into rom-elks.c using renamed routines rom_image_load and rom_term. This could be pulled out and used for ADVANTECH if later desired.