### PR TITLE
Cleanup exit code

### DIFF
--- a/char-stdio.c
+++ b/char-stdio.c
@@ -103,6 +103,7 @@ void char_normal ()
 
 static void catch_abort(int sig)
 	{
+	char_term();
 	exit(1);
 	}
 
@@ -120,7 +121,6 @@ int char_init ()
 	char_raw();
 
 	signal(SIGABRT, catch_abort);
-	atexit(char_term);
 	return 0;
 	}
 
@@ -129,4 +129,3 @@ void char_term ()
 	{
 	if (def_termios.c_oflag) char_normal();
 	}
-

--- a/emu-main.c
+++ b/emu-main.c
@@ -27,9 +27,6 @@
 #define MAINLOOP_TIMER 10000
 static int mainloop_count = 0;
 
-extern int image_load (char * path);
-extern void image_close (void);
-
 static int file_load (addr_t start, char * path)
 	{
 	int err = -1;
@@ -601,10 +598,7 @@ int main (int argc, char * argv [])
 	con_term ();
 	serial_term ();
 
-	// Asked by @ghaerr in https://github.com/mfld-fr/emu86/pull/37#issuecomment-830708810
-	// Because there are still some exit() in the code path
-	//return (err >= 0) ? EXIT_SUCCESS : EXIT_FAILURE;
-	_exit ((err >= 0) ? EXIT_SUCCESS : EXIT_FAILURE);
+	return (err >= 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 	}
 
 //------------------------------------------------------------------------------

--- a/timer-elks.c
+++ b/timer-elks.c
@@ -9,7 +9,7 @@
 
 #define TIMER_MAX 3000
 
-int timer_enabled = 0;
+static int timer_enabled = 0;
 static int timer_count = 0;
 
 void timer_proc ()


### PR DESCRIPTION
Cleans up exit code. In my earlier comment, I mentioned 'exit' was called, but what I mean was 'assert', which calls exit.

This cleans that up, and some other stuff from previous commits.