### PR TITLE
Extend queuing to character console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,15 @@ ifeq ($(CONSOLE), none)
 endif
 
 ifeq ($(CONSOLE), stdio)
-	EMU86_OBJS += con-char.o char-stdio.o
+	EMU86_OBJS += emu-con.o con-char.o char-stdio.o
 endif
 
 ifeq ($(CONSOLE), pty)
-	EMU86_OBJS += con-char.o char-pty.o
+	EMU86_OBJS += emu-con.o con-char.o char-pty.o
 endif
 
 ifeq ($(CONSOLE), sdl)
-	EMU86_OBJS += con-sdl.o rom8x16.o
+	EMU86_OBJS += emu-con.o con-sdl.o rom8x16.o
 	CFLAGS += -DSDL=1
 	LDLIBS += -lSDL2
 endif

--- a/con-char.c
+++ b/con-char.c
@@ -38,24 +38,26 @@ int con_scrollup ()
 	return 0;
 	}
 
-int con_get_key (word_t * k)
-	{
-	byte_t c = 0;
-	int err = char_recv (&c);
-	*k = (word_t) c;
-	return err;
-	}
-
-
-int con_poll_key ()
-	{
-	return char_poll ();
-	}
 
 int con_proc ()
 	{
-	return 0;
+	int err;
+
+	while (1)
+		{
+		err = char_poll ();
+		if (err <= 0) break;
+
+		byte_t c = 0;
+		err = char_recv (&c);
+
+		if (!err) con_put_key ((word_t) c);
+		break;
+		}
+
+	return err;
 	}
+
 
 void con_raw ()
 	{
@@ -70,6 +72,7 @@ void con_normal ()
 
 int con_init ()
 	{
+	con_init_key ();
 	return char_init ();
 	}
 
@@ -78,3 +81,5 @@ void con_term ()
 	{
 	char_term ();
 	}
+
+//-------------------------------------------------------------------------------

--- a/con-none.c
+++ b/con-none.c
@@ -29,12 +29,12 @@ int con_scrollup ()
 int con_get_key (word_t * k)
 	{
 	*k = 0;
-	return 0;
+	return 1;  // no key
 	}
 
 int con_poll_key ()
 	{
-	return 0;
+	return 0;  // no key
 	}
 
 int con_proc ()

--- a/emu-con.c
+++ b/emu-con.c
@@ -1,0 +1,65 @@
+//------------------------------------------------------------------------------
+// EMU86 - Generic console
+//------------------------------------------------------------------------------
+
+#include "emu-con.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+
+
+// Keyboard queue
+// Key enqueued by con_proc() through con_put_key()
+// Key dequeued by con_get_key() & con_poll()
+
+typedef struct _key_s
+	{
+	list_s node;
+	word_t k;
+	} key_s;
+
+static list_s key_queue;
+
+
+void con_put_key (word_t k)
+	{
+	key_s * key = malloc (sizeof (key_s));
+	if (key) {
+		list_insert_after (&key_queue, &key->node);
+		key->k = k;
+		}
+	}
+
+
+int con_get_key (word_t * pk)
+	{
+	list_s * next = key_queue.next;
+
+	// WARNING : non-blocking call with SDL console
+	if (next == &key_queue) return 1;  // no key
+
+	key_s * key = structof (key_s, node, next);
+	*pk = key->k;
+
+	list_remove (next);
+	free (next);
+
+	return 0;  // got key
+	}
+
+
+int con_poll_key (void)
+	{
+	list_s * next = key_queue.next;
+	if (next != &key_queue) return 1;  // has key
+	return 0;  // no key
+	}
+
+
+void con_init_key ()
+	{
+	list_init (&key_queue);
+	}
+
+
+//------------------------------------------------------------------------------

--- a/emu-con.h
+++ b/emu-con.h
@@ -4,18 +4,29 @@
 
 #pragma once
 
+#include "list.h"
 #include "emu-types.h"
+
+// Screen emulation
 
 int con_put_char (byte_t c);
 int con_pos_set (byte_t row, byte_t col);
 int con_pos_get (byte_t *row, byte_t *col);
 int con_scrollup ();
 
+// Keyboard queue
+
+void con_init_key ();
+void con_put_key (word_t k);
 int con_get_key (word_t * k);
 int con_poll_key ();
 
+// Console modes
+
 void con_normal ();
 void con_raw ();
+
+// Console main
 
 int con_proc ();
 

--- a/emu-main.c
+++ b/emu-main.c
@@ -168,6 +168,7 @@ static int debug_proc ()
 				case '\n':
 					_flag_trace = 1;
 					_flag_prompt = 1;
+					_flag_exec = 1;
 					break;
 
 				// Continue tracing


### PR DESCRIPTION
As explained in #46, generalize the key queue to all consoles.

Also fix a little problem in debugger that did not step anymore after displaying the registers.