### PR TITLE
Fix disk id BIOS bug

### DIFF
--- a/rom-elks.c
+++ b/rom-elks.c
@@ -182,7 +182,7 @@ static struct diskinfo * find_drive (byte_t drive)
 	{
 	struct diskinfo *dp;
 
-	for (dp = diskinfo; dp <= &diskinfo[sizeof(diskinfo)/sizeof(diskinfo[0])]; dp++)
+	for (dp = diskinfo; dp < &diskinfo[sizeof(diskinfo)/sizeof(diskinfo[0])]; dp++)
 		if (dp->fd != -1 && dp->drive == drive)
 			return dp;
 	return NULL;
@@ -235,7 +235,7 @@ int rom_image_load (char * path)
 			break;
 		}
 
-		for (dp = diskinfo; dp <= &diskinfo[sizeof(diskinfo)/sizeof(diskinfo[0])]; dp++)
+		for (dp = diskinfo; dp < &diskinfo[sizeof(diskinfo)/sizeof(diskinfo[0])]; dp++)
 			{
 			if (dp->fd == -1)
 				{


### PR DESCRIPTION
Fixes incorrect disk ID bug found and reported by @cocus in https://github.com/mfld-fr/emu86/issues/47#issuecomment-833013392. 