### PR TITLE
Emulate text video adaptor RAM in SDL console

### DIFF
--- a/emu-mem-io.h
+++ b/emu-mem-io.h
@@ -9,6 +9,31 @@
 
 #define ROM_BASE 0x80000
 
+// EGA/MDA Adaptor
+
+#define VID_BASE		0xB8000		// EGA
+//#define VID_BASE		0xB0000		// MDA (mono)
+#define VID_COLS		80
+#define VID_LINES		25
+#define VID_SIZE		0x4000		// 16k
+#define VID_PAGE_SIZE	(VID_COLS * 2 * VID_LINES)
+
+// 6845 CRT Controller
+
+#define CRTC_IOBASE		0x03D4		// color
+//#define CRTC_IOBASE	0x03B4		// mono (MDA)
+
+// BIOS Data Area
+
+#define BDA_BASE		0x00400
+
+extern byte_t mem_stat [MEM_MAX];
+extern byte_t crtc_curhi, crtc_curlo;
+extern int vid_minx, vid_miny;
+extern int vid_maxx, vid_maxy;
+void update_dirty_region (int x, int y);
+void reset_dirty_region ();
+
 
 // Memory breakpoint
 

--- a/io-elks.c
+++ b/io-elks.c
@@ -10,6 +10,9 @@
 
 extern int info_level;
 
+byte_t crtc_curhi, crtc_curlo;		// 6845 CRTC cursor
+static byte_t crtc_lastcommand;
+
 //-------------------------------------------------------------------------------
 
 int io_read_byte (word_t p, byte_t * b)
@@ -39,7 +42,22 @@ int io_write_byte (word_t p, byte_t b)
 		case 0x43: // 8253 timer
 			// FIXME: base I/O port of timer ?
 			timer_io_write (p, b);
-			/* fall through */
+			break;
+
+		case 0x80:					// I/O delay
+			break;
+
+		case CRTC_IOBASE:			// 6845 CRTC
+			crtc_lastcommand = b;
+			break;
+
+		case CRTC_IOBASE+1:
+			if (crtc_lastcommand == 0x0E)
+				crtc_curhi = b;
+			else if (crtc_lastcommand == 0x0F)
+				crtc_curlo = b;
+			// set display page 0x0C/0x0D ignored
+			break;
 
 		default:
 			if (info_level & 4) printf("[OUTB %3xh AL %0xh]\n", p, b);

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -640,4 +640,11 @@ void rom_init (void)
 	mem_write_byte (0xFFFF0, 0xEA,   1);  // JMPF
 	mem_write_word (0xFFFF1, 0x0000, 1);
 	mem_write_word (0xFFFF3, 0xF000, 1);
+
+	// BIOS Data Area (BDA) setup for EGA/MDA adaptors
+
+	mem_write_byte (BDA_BASE+0x49, 0, 3); 			// video mode (7=MDA)
+	mem_write_byte (BDA_BASE+0x4a, VID_COLS, 1);	// console width
+	mem_write_word (BDA_BASE+0x4c, VID_PAGE_SIZE, 1); // page size
+	mem_write_word (BDA_BASE+0x63, CRTC_IOBASE, 1);	// 6845 CRTC base register
 	}


### PR DESCRIPTION
Note: this PR is not ready for merge yet. It is a working proof of concept, shown for discussion purposes.

This PR implements emulating EGA adaptor RAM as text characters, allowing programs that write directly to adaptor RAM at segment B800h to display on SDL console. 

Works with ELKS direct console for display.

Also implements BIOS console by updating video adaptor RAM on BIOS INT 10h text out/scroll calls.

Emulates Motorola 6845 CRT Controller for cursor display.

Emulates BIOS Data Area (BDA) necessary for ELKS Direct Console to operate.

Implements bounding box for fastest conversion of changed adaptor RAM to SDL pixels each update cycle. This means that adaptor RAM can be changed quickly without display, and during the next update cycle (every 10,000 instructions), the adaptor RAM is inspected, and only the bounding box of changed RAM is converted to text pixels in the SDL buffer and output. With no console output, current implementation only redraws the cursor each cycle. This may be able to be optimized out as well.

Bright/color attributes not implemented yet.
Only emulates EGA adaptor, not MDA (yet).

@mfld-fr : this may require some cleanup at your discretion after merge, regarding some variables made global for sharing, as well as where to put target-specific implementations. I will probably leave these to you, unless directed before merge. The main purpose of this preview is for you to take a look at it for comment.

Tested on ELKS Direct and BIOS consoles, not tested on Emscripten/browser yet.
Various lines of code are still left commented in, until debugging complete before merge.

The biggest problem, not yet solved, is that the ELKS Direct Console is married to the IRQ 1 keyboard handler, which is a big job to emulate, because of the delivery of keystrokes via scan codes. I plan on making a change in ELKS to allow compilation of Direct Console but using the scheduler timer callback to poll INT 16h for keyboard input just as headless and BIOS console does. Because of this, running EMU86 with Direct Console only properly displays the screen, but doesn't actually work, since keyboard input is not operational.