### PR TITLE
Fix INT 13h disk error vs unimplemented function

### DIFF
--- a/rom-elks.c
+++ b/rom-elks.c
@@ -325,6 +325,7 @@ static int int_13h ()
 	switch (ah)
 		{
 		case 0x00:  // reset drive
+			err = 0;
 			break;
 
 		case 0x02:  // read disk
@@ -381,11 +382,11 @@ static int int_13h ()
 
 		default:
 			printf ("fatal: INT 13h: AH=%hxh not implemented\n", ah);
-			assert (0);
+			return err;
 		}
 
 	flag_set (FLAG_CF, err? 1: 0);
-	return err;
+	return 0;
 	}
 
 


### PR DESCRIPTION
@mfld-fr : This fixes the INT 13h handler, which was broken by a commit that returned 'err' rather than 0 for implemented subfunctions.

Fixes #52.

The implementation is a little tricky: programs may call INT 13h and get failure returned by CF, for instance, when querying drive status to determine if drive exists. This "error" condition cannot be interpreted by EMU86 as INT 13h failure.

Now, INT 13h only stops emulator on unimplemented functions.

Also fixes INT 13h AH=0 (reset).