### PR TITLE
Implement transparent cursor and reverse video in SDL backend

### DIFF
--- a/rom-elks.c
+++ b/rom-elks.c
@@ -666,4 +666,6 @@ void rom_init (void)
 	*(byte_t *) (mem_stat+BDA_BASE+0x4a) =  VID_COLS;		// console width
 	*(word_t *) (mem_stat+BDA_BASE+0x4c) =  VID_PAGE_SIZE;	// page size
 	*(word_t *) (mem_stat+BDA_BASE+0x63) =  CRTC_CTRL_PORT;	// 6845 CRTC
+
+	memset (mem_stat+VID_BASE, 0x00, VID_PAGE_SIZE);		// clear text RAM
 	}


### PR DESCRIPTION
This PR adds fully working (transparent overlay) cursor, as well as reverse video display in SDL backend.

ELKS `vi` now works and displays well.