### PR TITLE
Remove assert calls from ELKS BIOS

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -25,7 +25,7 @@ PLATFORM=terminal
 #CONSOLE=none
 CONSOLE=stdio
 #CONSOLE=pty
-CONSOLE=sdl
+#CONSOLE=sdl
 
 # Serial backend
 # none:  no serial backend

--- a/config.mk
+++ b/config.mk
@@ -25,7 +25,7 @@ PLATFORM=terminal
 #CONSOLE=none
 CONSOLE=stdio
 #CONSOLE=pty
-#CONSOLE=sdl
+CONSOLE=sdl
 
 # Serial backend
 # none:  no serial backend

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -138,8 +138,7 @@ static int int_10h ()
 
 		default:
 		notimp:
-			fflush(stdout);
-			printf ("fatal: INT 10h: AH=%hxh not implemented\n", ah);
+			printf ("error: INT 10h: AH=%hxh not implemented\n", ah);
 			return -1;
 		}
 
@@ -380,7 +379,7 @@ static int int_13h ()
 			break;
 
 		default:
-			printf ("fatal: INT 13h: AH=%hxh not implemented\n", ah);
+			printf ("error: INT 13h: AH=%hxh not implemented\n", ah);
 			return err;
 		}
 
@@ -496,7 +495,7 @@ static int int_17h ()
 	switch (ah)
 		{
 		default:
-			printf ("fatal: INT 17h: AH=%hxh not implemented\n", ah);
+			printf ("error: INT 17h: AH=%hxh not implemented\n", ah);
 			return -1;
 		}
 
@@ -537,7 +536,7 @@ static int int_1Ah ()
 			break;
 
 		default:
-			printf ("fatal: INT 1Ah: AH=%hxh not implemented\n", ah);
+			printf ("error: INT 1Ah: AH=%hxh not implemented\n", ah);
 			return -1;
 		}
 

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -7,7 +7,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <fcntl.h>
-#include <assert.h>
 #include <sys/stat.h>
 
 #include "emu-mem-io.h"
@@ -141,7 +140,7 @@ static int int_10h ()
 		notimp:
 			fflush(stdout);
 			printf ("fatal: INT 10h: AH=%hxh not implemented\n", ah);
-			assert (0);
+			return -1;
 		}
 
 	return 0;
@@ -498,7 +497,7 @@ static int int_17h ()
 		{
 		default:
 			printf ("fatal: INT 17h: AH=%hxh not implemented\n", ah);
-			assert (0);
+			return -1;
 		}
 
 	return 0;
@@ -539,7 +538,7 @@ static int int_1Ah ()
 
 		default:
 			printf ("fatal: INT 1Ah: AH=%hxh not implemented\n", ah);
-			assert (0);
+			return -1;
 		}
 
 	return 0;


### PR DESCRIPTION
Fixes request in #15 to remove assertions in BIOS emulation. This touches ELKS BIOS only.