### PR TITLE
Fix ELKS ROM BIOS to handle video text attributes

### DIFF
--- a/con-char.c
+++ b/con-char.c
@@ -8,7 +8,7 @@
 
 int con_put_char (word_t c)
 	{
-	return char_send (c & 0xFF);
+	return char_send (c);
 	}
 
 

--- a/con-char.c
+++ b/con-char.c
@@ -6,9 +6,9 @@
 #include "emu-char.h"  // generic character backend
 
 
-int con_put_char (byte_t c)
+int con_put_char (word_t c)
 	{
-	return char_send (c);
+	return char_send (c & 0xFF);
 	}
 
 
@@ -33,7 +33,7 @@ int con_pos_get (byte_t *row, byte_t *col)
 	return 0;
 	}
 
-int con_scrollup ()
+int con_scrollup (byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2)
 	{
 	return 0;
 	}

--- a/con-none.c
+++ b/con-none.c
@@ -5,7 +5,7 @@
 #include "emu-con.h"   // generic console
 
 
-int con_put_char (byte_t c)
+int con_put_char (word_t c)
 	{
 	return 0;
 	}
@@ -21,7 +21,7 @@ int con_pos_get (byte_t *row, byte_t *col)
 	return 0;
 	}
 
-int con_scrollup ()
+int con_scrollup (byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2)
 	{
 	return 0;
 	}

--- a/con-sdl.c
+++ b/con-sdl.c
@@ -137,7 +137,7 @@ void sdl_textout(word_t c)
 {
 	cursoroff();
 
-	switch (c & 0xFF) {
+	switch (c & ATTR_CHARMASK) {
 	case '\0':	return;
 	case '\b':	if (--curx <= 0) curx = 0; goto update;
 	case '\r':	curx = 0; goto update;

--- a/con-sdl.c
+++ b/con-sdl.c
@@ -54,8 +54,8 @@ static void sdl_drawbitmap(int c, int x, int y)
     int bitcount = 0;
 	unsigned short bitvalue = 0;
 	int height = CHAR_HEIGHT;
-	char fg = (c & ATTR_FGCOLOR)? 255: 0;	// bright white fg for now
-	char bg = (c & ATTR_BGCOLOR)? 192: 0;	// medium white bg on reverse video
+	unsigned char fg = (c & ATTR_FGCOLOR)? 255: 0;	// bright white fg for now
+	unsigned char bg = (c & ATTR_BGCOLOR)? 192: 0;	// medium white bg on reverse video
 
     while (height > 0) {
 		unsigned char *pixels;
@@ -124,6 +124,7 @@ static void scrollup(void)
 {
 	int pitch = COLS * 2;
 	byte_t *vid = mem_stat + VID_BASE;
+
 	memcpy(vid, vid + pitch, (LINES-1) * pitch);
 	memset(vid + (LINES-1) * pitch, 0, pitch);
 	update_dirty_region (0, 0);
@@ -132,18 +133,18 @@ static void scrollup(void)
 
 
 /* output character at cursor location*/
-void sdl_textout(unsigned char c)
+void sdl_textout(word_t c)
 {
 	cursoroff();
 
-	switch (c) {
+	switch (c & 0xFF) {
 	case '\0':	return;
 	case '\b':	if (--curx <= 0) curx = 0; goto update;
 	case '\r':	curx = 0; goto update;
 	case '\n':  goto scroll;
 	}
 
-	mem_stat[VID_BASE + (cury * COLS + curx) * 2] = c;
+	*(word_t *)&mem_stat[VID_BASE + (cury * COLS + curx) * 2] = c;
 	update_dirty_region (curx, cury);
 
 	if (++curx >= COLS) {
@@ -160,7 +161,7 @@ update:
 }
 
 
-int con_put_char (byte_t c)
+int con_put_char (word_t c)
 	{
 	sdl_textout(c);
 	return 0;
@@ -188,10 +189,20 @@ int con_pos_get (byte_t *row, byte_t *col)
 	}
 
 
-int con_scrollup ()
+int con_scrollup (byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2)
 	{
+	byte_t x;
+
 	cursoroff();
-	scrollup();
+	if (n == 0 || n >= VID_LINES)
+		{
+			for (x = c; x <= c2; x++) {
+				*(word_t *)&mem_stat[VID_BASE + (r * VID_COLS + x) * 2] = ' ' | 0x0700;
+				update_dirty_region(x, r);
+			}
+		}
+		else if (r != r2)
+			scrollup();
 	cursoron();
 	return 0;
 	}

--- a/emu-con.h
+++ b/emu-con.h
@@ -9,10 +9,10 @@
 
 // Screen emulation
 
-int con_put_char (byte_t c);
+int con_put_char (word_t c);
 int con_pos_set (byte_t row, byte_t col);
 int con_pos_get (byte_t *row, byte_t *col);
-int con_scrollup ();
+int con_scrollup (byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2);
 
 // Keyboard queue
 

--- a/mem-io-elks.h
+++ b/mem-io-elks.h
@@ -13,7 +13,8 @@
 #define VID_SIZE		0x4000		// 16k
 #define VID_PAGE_SIZE	(VID_COLS * 2 * VID_LINES)
 
-#define ATTR_NORMAL		0x0700
+#define ATTR_CHARMASK	0x00FF		// character position
+#define ATTR_NORMAL		0x0700		// white on black
 
 // 6845 CRT Controller
 

--- a/mem-io-elks.h
+++ b/mem-io-elks.h
@@ -13,6 +13,8 @@
 #define VID_SIZE		0x4000		// 16k
 #define VID_PAGE_SIZE	(VID_COLS * 2 * VID_LINES)
 
+#define ATTR_NORMAL		0x0700
+
 // 6845 CRT Controller
 
 #define CRTC_CTRL_PORT	0x03D4		// color

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -41,6 +41,7 @@ static int int_10h ()
 	addr_t a;
 	byte_t r;  // row
 	byte_t c;  // column
+	byte_t r2, c2, n, at;
 
 //printf("INT 10h fn %x\n", ah);
 	switch (ah)
@@ -69,21 +70,33 @@ static int int_10h ()
 		// Scroll up
 
 		case 0x06:
-			con_scrollup();			// ignores row/col numbers
+			n = reg8_get (REG_AL); 	// # lines
+			at = reg8_get (REG_BH); // attribute
+			r = reg8_get (REG_CH);  // upper L/R
+			c = reg8_get (REG_CL);
+			r2 = reg8_get (REG_DH);	// lower L/R
+			c2 = reg8_get (REG_DL);
+			con_scrollup (n, at, r, c, r2, c2);
 			break;
 
-		// Write character at current cursor position
+		// Write character and attribute at current cursor position
 
 		case 0x09:
+			at = reg8_get (REG_BL); // attribute
+			con_put_char (reg8_get (REG_AL) | at << 8);	// CX count igored
+			break;
+
+		// Write character only at current cursor position
+
 		case 0x0A:
-			con_put_char (reg8_get (REG_AL));
+			con_put_char (reg8_get (REG_AL) | ATTR_NORMAL);
 			break;
 
 		// Write as teletype to current page
 		// Page ignored in video mode 7
 
 		case 0x0E:
-			con_put_char (reg8_get (REG_AL));
+			con_put_char (reg8_get (REG_AL) | ATTR_NORMAL);
 			break;
 
 		// Get video mode


### PR DESCRIPTION
Fixes character display on ELKS compiled with BIOS Console. Discussed in https://github.com/mfld-fr/emu86/pull/54#issuecomment-835842510.

Implements more complete PC BIOS INT 10h AH=06h Scrollup specification.

Currently, ROM BIOS mem_stat manipulations are mostly handled in con-sdl.c SDL backend, but for full compatibility with video RAM emulation, may want to be moved to rom-xxx.c implementation.

`con_put_char` must now be passed video attribute (usually ATTR_NORMAL) for SDL backend. Should work with stdio and character backends where attribute is discarded.

`vi` now works well on Direct and BIOS Consoles.