### PR TITLE
rom-pcxtat: fix buggy keyboard peek logic.

### DIFF
--- a/rom-pcxtat.c
+++ b/rom-pcxtat.c
@@ -584,21 +584,24 @@ static int int_16h ()
 			break;
 
 		// Peek character
-		// FIXME: buggy around key_prev
 
 		case 0x01:
 		case 0x11:
-			if (!con_poll_key ())
+			// Do we have a character previously read?
+			if (key_prev == 0)
 				{
-				flag_set (FLAG_ZF, 1);  // no character in queue
-				break;
+				// Nope, ask the console for a new one
+				if (!con_poll_key ())
+					{
+						flag_set (FLAG_ZF, 1);  // no character in queue
+						break;
+					}
+
+				err = con_get_key (&key_prev);
+				if (err) break;
 				}
 
 			flag_set (FLAG_ZF, 0);
-
-			err = con_get_key (&key_prev);
-			if (err) break;
-
 			reg8_set (REG_AL, (byte_t) key_prev);
 			goto convert;
 


### PR DESCRIPTION
If there was a previously peek character, use that one
instead of asking the console to poll for a new key press.