### PR TITLE
Add scroll down ELKS/PC ROM BIOS, initial MDA support

### DIFF
--- a/con-char.c
+++ b/con-char.c
@@ -33,7 +33,7 @@ int con_pos_get (byte_t *row, byte_t *col)
 	return 0;
 	}
 
-int con_scrollup (byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2)
+int con_scroll (int dn, byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2)
 	{
 	return 0;
 	}

--- a/con-none.c
+++ b/con-none.c
@@ -21,7 +21,7 @@ int con_pos_get (byte_t *row, byte_t *col)
 	return 0;
 	}
 
-int con_scrollup (byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2)
+int con_scroll (int dn, byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2)
 	{
 	return 0;
 	}

--- a/con-sdl.c
+++ b/con-sdl.c
@@ -18,16 +18,14 @@
 #include "mem-io-elks.h"
 
 /* configurable parameters*/
-#define COLS		80
-#define LINES		25
 #define CHAR_WIDTH	8
 #define CHAR_HEIGHT	16
 #define BPP			32			/* bits per pixel*/
 extern MWIMAGEBITS rom8x16_bits[];
 
 /* calculated parameters*/
-#define WIDTH		(COLS * CHAR_WIDTH)
-#define HEIGHT		(LINES * CHAR_HEIGHT)
+#define WIDTH		(VID_COLS * CHAR_WIDTH)
+#define HEIGHT		(VID_LINES * CHAR_HEIGHT)
 #define PITCH		(WIDTH * (BPP >> 3))
 
 /* display attributes*/
@@ -36,6 +34,9 @@ extern MWIMAGEBITS rom8x16_bits[];
 #define ATTR_BGCOLOR 0x7000
 #define ATTR_BOLD    0x0800
 #define ATTR_FGCOLOR 0x0700
+
+#define FG_WHITE 0x07
+#define BG_BLACK 0x00
 
 static SDL_Window *sdlWindow;
 static SDL_Renderer *sdlRenderer;
@@ -47,6 +48,30 @@ static int curx, cury;
 
 #define RGBDEF(r,g,b)	{ r,g,b,255 }
 struct rgba { unsigned char r, g, b, a; };
+
+#if VID_MODE == 7
+
+// MDA palette for attribute mapping
+static struct rgba EGA_COLORMAP[16] = {
+	RGBDEF( 0  , 0  , 0   ),	/* black*/
+	RGBDEF( 0  , 192, 0   ),	/* blue*/
+	RGBDEF( 0  , 192, 0   ),	/* green*/
+	RGBDEF( 0  , 192, 0   ),	/* cyan*/
+	RGBDEF( 0  , 192, 0   ),	/* red*/
+	RGBDEF( 0  , 192, 0   ),	/* magenta*/
+	RGBDEF( 0  , 192, 0   ),	/* adjusted brown*/
+	RGBDEF( 0  , 192, 0   ),	/* ltgray*/
+	RGBDEF( 0  , 0  , 0   ),	/* gray*/
+	RGBDEF( 0  , 255, 0   ),	/* ltblue*/
+	RGBDEF( 0  , 255, 0   ),	/* ltgreen*/
+	RGBDEF( 0  , 255, 0   ),	/* ltcyan*/
+	RGBDEF( 0  , 255, 0   ),	/* ltred*/
+	RGBDEF( 0  , 255, 0   ),	/* ltmagenta*/
+	RGBDEF( 0  , 255, 0   ),	/* yellow*/
+	RGBDEF( 0  , 255, 0   ),	/* white*/
+};
+
+#else
 
 // 16 color EGA palette for attribute mapping
 static struct rgba EGA_COLORMAP[16] = {
@@ -67,6 +92,8 @@ static struct rgba EGA_COLORMAP[16] = {
 	RGBDEF( 255, 255, 0   ),	/* yellow*/
 	RGBDEF( 255, 255, 255 ),	/* white*/
 };
+#endif
+
 
 /* draw a character bitmap*/
 static void sdl_drawbitmap(int c, int x, int y)
@@ -78,6 +105,16 @@ static void sdl_drawbitmap(int c, int x, int y)
 	unsigned short bitvalue = 0;
 	int height = CHAR_HEIGHT;
 
+#if VID_MODE == 7
+	// Special MDA handling
+	// 0x00, 0x08, 0x80, 0x88 (blank) -> 0x00, otherwise 0x07
+	// 0x70, 0x78, 0xF0, 0xF8 (reverse video) -> 0x70, otherwise 0x07
+	// MDA requires attribute 0x0700 for reverse video
+	if ((c & 0x7700) != 0x7000 && (c & 0x7700) != 0x0000) {
+		c |= ATTR_FGCOLOR;
+		c &= ~ATTR_BGCOLOR;
+	}
+#endif
 	int fg_color = (c & ATTR_FGCOLOR) >> 8;
 	if (c & ATTR_BOLD) fg_color += 8;
 	int bg_color = (c & ATTR_BGCOLOR) >> 12;
@@ -126,7 +163,7 @@ static void draw_video_ram(int sx, int sy, int ex, int ey)
 
 	for (y = sy; y < ey; y++)
 	{
-		int j = y * COLS + sx;
+		int j = y * VID_COLS + sx;
 		for (x = sx; x < ex; x++)
 		{
 			sdl_drawbitmap(vidram[j], x * CHAR_WIDTH, y * CHAR_HEIGHT);
@@ -140,7 +177,7 @@ static void cursoron(void)
 {
 	mem_stat[BDA_BASE+0x50] = curx;
 	mem_stat[BDA_BASE+0x51] = cury;
-	int pos = cury * COLS + curx;
+	int pos = cury * VID_COLS + curx;
 	crtc_curhi = pos >> 8;
 	crtc_curlo = pos & 0xff;
 }
@@ -149,17 +186,44 @@ static void cursoroff(void)
 {
 }
 
-
-// scroll adapter RAM
-static void scrollup(void)
+// clear line y from x1 up to and including x2 to attribute attr
+static void clear_line(int x1, byte_t x2, byte_t y, byte_t attr)
 {
-	int pitch = COLS * 2;
-	byte_t *vid = mem_stat + VID_BASE;
+	int x;
 
-	memcpy(vid, vid + pitch, (LINES-1) * pitch);
-	memset(vid + (LINES-1) * pitch, 0, pitch);
+	for (x = x1; x <= x2; x++) {
+		*(word_t *)&mem_stat[VID_BASE + (y * VID_COLS + x) * 2] = ' ' | (attr << 8);
+		update_dirty_region(x, y);
+	}
+}
+
+// scroll adapter RAM up from line y1 up to and including line y2
+static void scrollup(int y1, int y2, byte_t attr)
+{
+	int pitch = VID_COLS * 2;
+	byte_t *vid = mem_stat + VID_BASE + y1 * pitch;
+
+	memcpy(vid, vid + pitch, (VID_LINES - y1) * pitch);
+	clear_line (0, VID_COLS-1, y2, attr);
 	update_dirty_region (0, 0);
-	update_dirty_region (COLS-1, LINES-1);
+	update_dirty_region (VID_COLS-1, VID_LINES-1);
+}
+
+
+// scroll adapter RAM down from line y1 up to and including line y2
+static void scrolldn(int y1, int y2, byte_t attr)
+{
+	int pitch = VID_COLS * 2;
+	byte_t *vid = mem_stat + VID_BASE + (VID_LINES-1) * pitch;
+	int y = y2;
+
+	while (--y >= y1) {
+		memcpy (vid, vid - pitch, pitch);
+		vid -= pitch;
+	}
+	clear_line (0, VID_COLS-1, y1, attr);
+	update_dirty_region (0, 0);
+	update_dirty_region (VID_COLS-1, VID_LINES-1);
 }
 
 
@@ -175,17 +239,17 @@ void sdl_textout(byte_t c, byte_t a)
 	case '\n':  goto scroll;
 	}
 
-	mem_stat [VID_BASE + (cury * COLS + curx) * 2 + 0] = c;
-	mem_stat [VID_BASE + (cury * COLS + curx) * 2 + 1] = a;
+	mem_stat [VID_BASE + (cury * VID_COLS + curx) * 2 + 0] = c;
+	mem_stat [VID_BASE + (cury * VID_COLS + curx) * 2 + 1] = a;
 
 	update_dirty_region (curx, cury);
 
-	if (++curx >= COLS) {
+	if (++curx >= VID_COLS) {
 		curx = 0;
 scroll:
-		if (++cury >= LINES) {
-			scrollup();
-			cury = LINES - 1;
+		if (++cury >= VID_LINES) {
+			scrollup(0, VID_LINES - 1, FG_WHITE | BG_BLACK);
+			cury = VID_LINES - 1;
 		}
 	}
 
@@ -222,20 +286,18 @@ int con_pos_get (byte_t *row, byte_t *col)
 	}
 
 
-int con_scrollup (byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2)
+int con_scroll (int dn, byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2)
 	{
-	byte_t x;
-
 	cursoroff();
 	if (n == 0 || n >= VID_LINES)
+		clear_line(c, c2, r, at);
+	else if (r != r2)
 		{
-			for (x = c; x <= c2; x++) {
-				*(word_t *)&mem_stat[VID_BASE + (r * VID_COLS + x) * 2] = ' ' | 0x0700;
-				update_dirty_region(x, r);
-			}
+		// FIXME count n, c, c2 ignored
+		if (dn)
+			scrolldn(r, r2, at);
+		else scrollup(r, r2, at);
 		}
-		else if (r != r2)
-			scrollup();
 	cursoron();
 	return 0;
 	}
@@ -372,8 +434,8 @@ int con_proc ()
 		{
 		// draw cursor
 		int pos = (crtc_curhi << 8) | crtc_curlo;
-		int y = pos / COLS;
-		int x = pos % COLS;
+		int y = pos / VID_COLS;
+		int x = pos % VID_COLS;
 		if (lastx != x || lasty != y || needscursor)
 			{
 			// remove last cursor

--- a/config.mk
+++ b/config.mk
@@ -5,9 +5,9 @@
 # advtech: Advantech SNMP-1000 SBC
 # pcxtat:  legacy PC/XT/AT (experimental)
 
+TARGET=pcxtat
 #TARGET=elks
 #TARGET=advtech
-TARGET=pcxtat
 
 # Platform selection
 # terminal:   standard 

--- a/emu-con.h
+++ b/emu-con.h
@@ -12,7 +12,7 @@
 int con_put_char (byte_t c, byte_t a);
 int con_pos_set (byte_t row, byte_t col);
 int con_pos_get (byte_t *row, byte_t *col);
-int con_scrollup (byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2);
+int con_scroll (int dn, byte_t n, byte_t at, byte_t r, byte_t c, byte_t r2, byte_t c2);
 
 // Keyboard queue
 

--- a/mem-elks.c
+++ b/mem-elks.c
@@ -25,7 +25,8 @@ void reset_dirty_region ()
 
 void mem_write_byte (addr_t a, byte_t b, byte_t init)
 	{
-	if (a >= VID_BASE && a < (VID_BASE + VID_SIZE))
+	// FIXME change VID_PAGE_SIZE to VID_SIZE when pages implemented
+	if (a >= VID_BASE && a < (VID_BASE + VID_PAGE_SIZE))
 		{
 		byte_t * p = (byte_t *) mem_get_addr (a);
 		*p = b;
@@ -47,7 +48,8 @@ void mem_write_byte (addr_t a, byte_t b, byte_t init)
 
 void mem_write_word (addr_t a, word_t w, byte_t init)
 	{
-	if (a >= VID_BASE && a < (VID_BASE + VID_SIZE))
+	// FIXME change VID_PAGE_SIZE to VID_SIZE when pages implemented
+	if (a >= VID_BASE && a < (VID_BASE + VID_PAGE_SIZE))
 		{
 		word_t * p = (word_t *) mem_get_addr (a);
 		*p = w;

--- a/mem-elks.c
+++ b/mem-elks.c
@@ -1,11 +1,21 @@
+//
+// EGA / MDA Video read/write routines
+//
 
 #include "emu-mem-io.h"
 #include "mem-io-elks.h"
+#include "rom-bios.h"
 
 int vid_minx = 32767, vid_miny = 32767;
 int vid_maxx = -1, vid_maxy = -1;
 #define MIN(a,b)      ((a) < (b) ? (a) : (b))
 #define MAX(a,b)      ((a) > (b) ? (a) : (b))
+
+// return video RAM base address based on video mode
+int vid_base (void)
+	{
+		return mem_stat [BDA_VIDEO_MODE] == 7? 0xB0000: 0xB8000;
+	}
 
 void update_dirty_region (int x, int y)
 	{
@@ -26,13 +36,13 @@ void reset_dirty_region ()
 void mem_write_byte (addr_t a, byte_t b, byte_t init)
 	{
 	// FIXME change VID_PAGE_SIZE to VID_SIZE when pages implemented
-	if (a >= VID_BASE && a < (VID_BASE + VID_PAGE_SIZE))
+	if (a >= vid_base() && a < (vid_base() + VID_PAGE_SIZE))
 		{
 		byte_t * p = (byte_t *) mem_get_addr (a);
 		*p = b;
 
 		// calculate bounding rectangle
-		a = (a - VID_BASE) / 2;
+		a = (a - vid_base()) / 2;
 		update_dirty_region(a % VID_COLS, a / VID_COLS);
 		}
 
@@ -49,13 +59,13 @@ void mem_write_byte (addr_t a, byte_t b, byte_t init)
 void mem_write_word (addr_t a, word_t w, byte_t init)
 	{
 	// FIXME change VID_PAGE_SIZE to VID_SIZE when pages implemented
-	if (a >= VID_BASE && a < (VID_BASE + VID_PAGE_SIZE))
+	if (a >= vid_base() && a < (vid_base() + VID_PAGE_SIZE))
 		{
 		word_t * p = (word_t *) mem_get_addr (a);
 		*p = w;
 
 		// calculate bounding rectangle
-		a = (a - VID_BASE) / 2;
+		a = (a - vid_base()) / 2;
 		update_dirty_region(a % VID_COLS, a / VID_COLS);
 		}
 

--- a/mem-io-elks.h
+++ b/mem-io-elks.h
@@ -7,7 +7,10 @@
 // EGA/MDA Adaptor
 
 #define VID_BASE		0xB8000		// EGA
+#define VID_MODE		3
 //#define VID_BASE		0xB0000		// MDA (mono)
+//#define VID_MODE		7
+
 #define VID_COLS		80
 #define VID_LINES		25
 #define VID_SIZE		0x4000		// 16k

--- a/mem-io-elks.h
+++ b/mem-io-elks.h
@@ -3,13 +3,7 @@
 
 #include "emu-types.h"
 
-
-// EGA/MDA Adaptor
-
-#define VID_BASE		0xB8000		// EGA
-#define VID_MODE		3
-//#define VID_BASE		0xB0000		// MDA (mono)
-//#define VID_MODE		7
+// Video
 
 #define VID_COLS		80
 #define VID_LINES		25
@@ -35,5 +29,7 @@
 extern byte_t crtc_curhi, crtc_curlo;
 extern int vid_minx, vid_miny;
 extern int vid_maxx, vid_maxy;
+
+int vid_base(void);
 void update_dirty_region (int x, int y);
 void reset_dirty_region ();

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -554,10 +554,10 @@ void rom_init (void)
 	// BIOS Data Area (BDA) setup for EGA/MDA adaptors
 
 	memset (mem_stat+BDA_BASE, 0x00, 256);
-	mem_stat [BDA_VIDEO_MODE] = VID_MODE;  // video mode (3=EGA 7=MDA)
+	mem_stat [BDA_VIDEO_MODE] = 3;  // video mode (3=EGA 7=MDA)
 	*(byte_t *) (mem_stat+BDA_BASE+0x4a) =  VID_COLS;		// console width
 	*(word_t *) (mem_stat+BDA_BASE+0x4c) =  VID_PAGE_SIZE;	// page size
 	*(word_t *) (mem_stat+BDA_BASE+0x63) =  CRTC_CTRL_PORT;	// 6845 CRTC
 
-	memset (mem_stat+VID_BASE, 0x00, VID_PAGE_SIZE);		// clear text RAM
+	memset (mem_stat+vid_base(), 0x00, VID_PAGE_SIZE);		// clear text RAM
 	}

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -56,16 +56,17 @@ static int int_10h ()
 		case 0x05:		// FIXME page required for multiple consoles
 			break;
 
-		// Scroll up
+		// Scroll up/down
 
-		case 0x06:
+		case 0x06:		// up
+		case 0x07:		// down
 			n = reg8_get (REG_AL); 	// # lines
 			at = reg8_get (REG_BH); // attribute
 			r = reg8_get (REG_CH);  // upper L/R
 			c = reg8_get (REG_CL);
 			r2 = reg8_get (REG_DH);	// lower L/R
 			c2 = reg8_get (REG_DL);
-			con_scrollup (n, at, r, c, r2, c2);
+			con_scroll (ah == 0x07, n, at, r, c, r2, c2);
 			break;
 
 		// Write character and attribute at current cursor position
@@ -336,7 +337,7 @@ static int int_13h ()
 			reg8_set (REG_CL, dp->sectors | (((c >> 8) & 0x03) << 6));
 			reg8_set (REG_DH, dp->heads - 1);
 			seg_set (SEG_ES, 0xFF00);   // fake DDPT, same as INT 1Eh
-			reg16_set (REG_DI, 0x0000);
+			reg16_set (REG_DI, 0x0000);	// FIXME wrong address
 			err = 0;
 			break;
 
@@ -553,7 +554,7 @@ void rom_init (void)
 	// BIOS Data Area (BDA) setup for EGA/MDA adaptors
 
 	memset (mem_stat+BDA_BASE, 0x00, 256);
-	*(byte_t *) (mem_stat+BDA_BASE+0x49) =  3; 				// video mode (3= EGA 7=MDA)
+	mem_stat [BDA_VIDEO_MODE] = VID_MODE;  // video mode (3=EGA 7=MDA)
 	*(byte_t *) (mem_stat+BDA_BASE+0x4a) =  VID_COLS;		// console width
 	*(word_t *) (mem_stat+BDA_BASE+0x4c) =  VID_PAGE_SIZE;	// page size
 	*(word_t *) (mem_stat+BDA_BASE+0x63) =  CRTC_CTRL_PORT;	// 6845 CRTC

--- a/rom-pcxtat.c
+++ b/rom-pcxtat.c
@@ -98,23 +98,17 @@ static int int_10h ()
 		case 0x05:
 			break;
 
-		// Scroll up
+		// Scroll up/down
 
-		case 0x06:
+		case 0x06:		// up
+		case 0x07:		// down
 			n = reg8_get (REG_AL); 	// # lines
 			at = reg8_get (REG_BH); // attribute
 			r = reg8_get (REG_CH);  // upper L/R
 			c = reg8_get (REG_CL);
 			r2 = reg8_get (REG_DH);	// lower L/R
 			c2 = reg8_get (REG_DL);
-			con_scrollup (n, at, r, c, r2, c2);
-			break;
-
-		// Scroll down
-
-		case 0x07:
-			puts ("\nwarning: INT 10h AH=07h: no scroll up supported");
-			//con_scrolldown();
+			con_scroll (ah == 0x07, n, at, r, c, r2, c2);
 			break;
 
 		// Read character at current cursor position
@@ -845,7 +839,7 @@ void rom_init (void)
 	// BIOS Data Area (BDA) setup for EGA/MDA adaptors
 
 	memset (mem_stat+BDA_BASE, 0x00, 256);
-	mem_stat [BDA_VIDEO_MODE] = 3;  // color 80x25 character (EGA)
+	mem_stat [BDA_VIDEO_MODE] = VID_MODE;  // video mode (3=EGA 7=MDA)
 	*(byte_t *) (mem_stat+BDA_BASE+0x4a) =  VID_COLS;		// console width
 	*(word_t *) (mem_stat+BDA_BASE+0x4c) =  VID_PAGE_SIZE;	// page size
 	*(word_t *) (mem_stat+BDA_BASE+0x63) =  CRTC_CTRL_PORT;	// 6845 CRTC

--- a/rom-pcxtat.c
+++ b/rom-pcxtat.c
@@ -839,10 +839,10 @@ void rom_init (void)
 	// BIOS Data Area (BDA) setup for EGA/MDA adaptors
 
 	memset (mem_stat+BDA_BASE, 0x00, 256);
-	mem_stat [BDA_VIDEO_MODE] = VID_MODE;  // video mode (3=EGA 7=MDA)
+	mem_stat [BDA_VIDEO_MODE] = 3;  // video mode (3=EGA 7=MDA)
 	*(byte_t *) (mem_stat+BDA_BASE+0x4a) =  VID_COLS;		// console width
 	*(word_t *) (mem_stat+BDA_BASE+0x4c) =  VID_PAGE_SIZE;	// page size
 	*(word_t *) (mem_stat+BDA_BASE+0x63) =  CRTC_CTRL_PORT;	// 6845 CRTC
 
-	memset (mem_stat+VID_BASE, 0x00, VID_PAGE_SIZE);		// clear text RAM
+	memset (mem_stat+vid_base(), 0x00, VID_PAGE_SIZE);		// clear text RAM
 	}


### PR DESCRIPTION
ELKS `vi` uses ROM BIOS scroll up/down; this PR implements that and enhances BIOS scrolling to work in all cases.
`con_scrollup` API changed to `con_scroll` with direction parameter.
Added to PC and ELKS ROM BIOS.
Fixes various other issues with attributes passed via BIOS functions.
More cleanup of con-sdl.c.

Adds initial MDA support with special attribute handling.
In the future could be dynamic, this version enable by setting `VID_MODE` in mem-io-elks.h.

