### PR TITLE
Fix macOS printf format warning

### DIFF
--- a/emu-main.c
+++ b/emu-main.c
@@ -51,7 +51,7 @@ static int file_load (addr_t start, char * path)
 			break;
 			}
 
-		printf ("info: file size=%lXh\n", size);
+		printf ("info: file size=%lXh\n", (long)size);
 		if (start + size > MEM_MAX)
 			{
 			puts ("fatal: file too big");


### PR DESCRIPTION
Portable fix for clang and gcc as requested in https://github.com/mfld-fr/emu86/issues/59#issuecomment-838240003.

With this change, warnings as errors can be turned back on via `-Werror`.