### PR TITLE
Refine MDA attributes and IPS option

### DIFF
--- a/emu-main.c
+++ b/emu-main.c
@@ -100,7 +100,7 @@ static int _flag_filter = 0;  // filter traces
 static int _flag_prompt = 0;  // prompt for debug command
 static int _flag_exec   = 1;  // execute next instruction
 static int _flag_exit   = 0;  // exit main loop
-
+static int _flag_mon    = 0;  // monitor IPS
 
 static int debug_proc ()
 	{
@@ -399,6 +399,7 @@ static void usage (char * argv0)
 	puts ("  -d <address>         data breakpoint address");
 	puts ("  -t                   trace mode");
 	puts ("  -T                   filtered trace mode");
+	puts ("  -m                   monitor IPS (iteration / second)");
 	puts ("  -i                   interactive mode");
 	puts ("  -p                   program mode");
 	puts ("  -v <level>           verbose info level");
@@ -419,7 +420,7 @@ int command_line (int argc, char * argv [])
 
 	while (1)
 		{
-		opt = getopt (argc, argv, "w:f:I:x:c:d:v:tTip");
+		opt = getopt (argc, argv, "w:f:I:x:c:d:v:tTmip");
 		if (opt < 0 || opt == '?') break;
 
 		switch (opt)
@@ -506,6 +507,10 @@ int command_line (int argc, char * argv [])
 				_flag_filter = 1;
 				break;
 
+			case 'm':  // monitor mode
+				_flag_mon = 1;
+				break;
+
 			case 'i':  // interactive mode
 				_flag_trace = 1;
 				_flag_prompt = 1;
@@ -572,16 +577,12 @@ int command_line (int argc, char * argv [])
 // Main loop
 //------------------------------------------------------------------------------
 
-//#define IPS
-
-#ifdef IPS
 static int _flag_alarm = 0;
 
 static void sigalarm (int s)
 	{
 	_flag_alarm = 1;
 	}
-#endif
 
 
 static void sigint (int s)
@@ -636,12 +637,14 @@ int main (int argc, char * argv [])
 
 		// Use alarm signal for performance metering
 
-#ifdef IPS
 		int loop_count = 0;
-		sa.sa_handler = sigalarm;
-		sigaction (SIGALRM, &sa, NULL);
-		alarm (1);
-#endif
+
+		if (_flag_mon)
+			{
+			sa.sa_handler = sigalarm;
+			sigaction (SIGALRM, &sa, NULL);
+			alarm (1);
+			}
 
 		while (!_flag_exit)
 			{
@@ -681,17 +684,18 @@ int main (int argc, char * argv [])
 				mainloop_count = 0;
 				}
 
-#ifdef IPS
-			loop_count++;
-
-			if (_flag_alarm)
+			if (_flag_mon)
 				{
-				printf ("info: ips=%i\n", loop_count);
-				loop_count = 0;
-				_flag_alarm = 0;
-				alarm (1);
+				loop_count++;
+
+				if (_flag_alarm)
+					{
+					printf ("info: ips=%i\n", loop_count);
+					loop_count = 0;
+					_flag_alarm = 0;
+					alarm (1);
+					}
 				}
-#endif
 
 			}  // flag_exit
 

--- a/emu-mem-io.c
+++ b/emu-mem-io.c
@@ -58,9 +58,9 @@ int mem_write_byte_0 (addr_t a, byte_t b, byte_t init)
 
 	if (a >= ROM_BASE && !init)  // Protect ROM
 		{
-		printf ("\nfatal: writing byte into ROM @ %lXh\n", a);
+		printf ("\nwarning: writing byte into ROM @ %lXh\n", a);
 		// FIXME: hack to stop until error management
-		exit (0);
+		// exit (0);
 		err = -1;
 		}
 	else
@@ -82,9 +82,9 @@ int mem_write_word_0 (addr_t a, word_t w, byte_t init)
 
 	if (a >= (ROM_BASE - 1) && !init)  // Protect ROM
 		{
-		printf ("\nfatal: writing word into ROM @ %lxh\n", a);
+		printf ("\nwarning: writing word into ROM @ %lxh\n", a);
 		// FIXME: hack to stop until error management
-		exit (0);
+		// exit (0);
 		err = -1;
 		}
 	else

--- a/mem-io-elks.h
+++ b/mem-io-elks.h
@@ -4,13 +4,12 @@
 #include "emu-types.h"
 
 // Video
+// TODO: move to con-video.h
 
 #define VID_COLS		80
 #define VID_LINES		25
 #define VID_SIZE		0x4000		// 16k
 #define VID_PAGE_SIZE	(VID_COLS * 2 * VID_LINES)
-
-#define ATTR_NORMAL		0x07		// white on black
 
 // 6845 CRT Controller
 

--- a/rom-bios.h
+++ b/rom-bios.h
@@ -8,6 +8,13 @@
 #define BDA_VIDEO_MODE 0x0449
 
 
+// Default character attribute
+// Common MDA / EGA value
+// TODO: move to con-video.h
+
+#define ATTR_DEFAULT 0x07
+
+
 // Generic BIOS
 
 void rom_init_0 (void);

--- a/rom-elks.c
+++ b/rom-elks.c
@@ -2,13 +2,6 @@
 // EMU86 - ELKS ROM stub (BIOS)
 //------------------------------------------------------------------------------
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <string.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-
 #include "emu-mem-io.h"
 #include "emu-proc.h"
 #include "emu-con.h"
@@ -16,13 +9,18 @@
 #include "mem-io-elks.h"
 #include "rom-bios.h"
 
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
 
 extern int info_level;
 
 
 // BIOS video services
-
-#define BDA_VIDEO_MODE 0x0449
 
 static int int_10h ()
 	{
@@ -31,6 +29,7 @@ static int int_10h ()
 	byte_t r;  // row
 	byte_t c;  // column
 	byte_t r2, c2, n, at;
+
 	byte_t ah = reg8_get (REG_AH);
 
 	switch (ah)
@@ -72,15 +71,14 @@ static int int_10h ()
 		// Write character and attribute at current cursor position
 
 		case 0x09:
-			at = reg8_get (REG_BL); // attribute
-			con_put_char (reg8_get (REG_AL), at);  // CX count ignored
+			con_put_char (reg8_get (REG_AL), reg8_get (REG_BL));  // CX count ignored
 			break;
 
 		// Write as teletype to current page
-		// Page ignored in video mode 7
+		// Page ignored
 
 		case 0x0E:
-			con_put_char (reg8_get (REG_AL), ATTR_NORMAL);
+			con_put_char (reg8_get (REG_AL), ATTR_DEFAULT);
 			break;
 
 		// Get video mode


### PR DESCRIPTION
Move the attribute color logic out of the character rendering function, and make the BIOS attribute agnostic.
Also little cleanup of the PC/XT/AT BIOS, and new option to enable IPS.
Tested with FreeDOS HELP (8086tiny version) in both 3 and 7 modes.
