### PR TITLE
Add BDA equipment word specifying # disk drives

### DIFF
--- a/rom-elks.c
+++ b/rom-elks.c
@@ -559,5 +559,7 @@ void rom_init (void)
 	*(word_t *) (mem_stat+BDA_BASE+0x4c) =  VID_PAGE_SIZE;	// page size
 	*(word_t *) (mem_stat+BDA_BASE+0x63) =  CRTC_CTRL_PORT;	// 6845 CRTC
 
+	*(byte_t *) (mem_stat+BDA_BASE+0x10) =  0x81;			// 1 floppy
+
 	memset (mem_stat+VID_BASE, 0x00, VID_PAGE_SIZE);		// clear text RAM
 	}

--- a/rom-pcxtat.c
+++ b/rom-pcxtat.c
@@ -850,5 +850,7 @@ void rom_init (void)
 	*(word_t *) (mem_stat+BDA_BASE+0x4c) =  VID_PAGE_SIZE;	// page size
 	*(word_t *) (mem_stat+BDA_BASE+0x63) =  CRTC_CTRL_PORT;	// 6845 CRTC
 
+	*(byte_t *) (mem_stat+BDA_BASE+0x10) =  0x81;			// 1 floppy
+
 	memset (mem_stat+VID_BASE, 0x00, VID_PAGE_SIZE);		// clear text RAM
 	}


### PR DESCRIPTION
Found another hidden ELKS dependency: the BIOS disk driver peeks at the BIOS DATA Area equipment word at 0040:0010h to determine the number of disk drives present:
```
/* use BIOS to query floppy configuration*/
static unsigned short int INITPROC bioshd_getfdinfo(void)
{
    register struct drive_infot *drivep = &drive_info[DRIVE_FD0];
    int drive, ndrives = 0;

#ifndef CONFIG_ROMCODE
    /*
     * The INT 13h floppy query will fail on IBM XT v1 BIOS and earlier,
     * so default to # drives from the BIOS data area at 0x040:0x0010 (INT 11h).
     */
    unsigned char equip_flags = peekb(0x10, 0x40);
    if (equip_flags & 0x01)
    ndrives = (equip_flags >> 6) + 1;
#endif
```

This fixes regression found in https://github.com/mfld-fr/emu86/pull/68#issuecomment-841181775. The problem appeared in a previous commit that cleared the BDA.

More work to be done cleaning up ELKS, or at least documenting it!