### PR TITLE
Add text segment symbol display to disassembler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ EMU86_OBJS = \
 	op-exec.o \
 	emu-int.o \
 	emu-main.o \
+	mapfile.o
 	# end of list
 
 EMU86_OBJS += op-print-$(STYLE).o

--- a/config.mk
+++ b/config.mk
@@ -44,5 +44,5 @@ SERIAL=none
 # att:   AT&T syntax (GNU default)
 # intel: Intel syntax
 
-#STYLE=att
-STYLE=intel
+STYLE=att
+#STYLE=intel

--- a/convmap.c
+++ b/convmap.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int ac, char **av)
+{
+	FILE *fp;
+	char buf[128];
+
+	fp = fopen("file", "r");
+	if (!fp) exit(1);
+
+	printf("struct map { int addr; char *name; };\n");
+	printf("struct map map[] = {\n");
+	while(fgets(buf, sizeof(buf), fp) != NULL)
+	{
+		int addr;
+		unsigned char type;
+		char name[32];
+
+		if (sscanf(buf, "%x %c %s", &addr, &type, name) == 3)
+		{
+			// 0x10000+ is text
+			// 0x20000+ is far text
+			// 0x30000+ is data
+			if (addr >= 0x10000 && addr < 0x20000)
+			{
+				// TODO keep 0x10000 in address for near text
+				// otherwise seperate text, fartext and data maps required
+				addr -= 0x10000;
+				printf("{ 0x%04x, \"%s\" },\n", addr, name);
+			}
+		}
+	}
+	printf("{ -1, 0} };\n");
+	fclose(fp);
+}

--- a/convmap.sh
+++ b/convmap.sh
@@ -1,0 +1,4 @@
+cat ../elks-gh/elks/arch/i86/boot/system-nm.map | sed -e '/&/d; /!/d' | sort > file
+cc convmap.c -o convmap
+./convmap > mapfile.c
+rm file

--- a/mapfile.c
+++ b/mapfile.c
@@ -1,0 +1,3 @@
+struct map { int addr; char *name; };
+struct map map[] = {
+{ -1, 0} };

--- a/op-print-att.c
+++ b/op-print-att.c
@@ -19,6 +19,31 @@ extern word_t op_code_off;
 char op_code_str [3 * OPCODE_MAX + 2];
 byte_t op_code_pos;
 
+struct map { int addr; char *name; };
+extern struct map map[];
+
+// map near text address to symbol
+// TODO: far_text_symbol and data_name
+char *text_symbol(int addr)
+{
+	int i = 1;
+	static char buf[32];
+
+	while (addr >= map[i].addr)
+	{
+		if (map[i].addr == -1)
+		{
+			sprintf(buf, "%.4x", addr);	// fail, display hex address
+			return buf;
+		}
+		i++;
+	}
+	if (addr - map[i-1].addr)
+		sprintf(buf, "%s+%x", map[i-1].name, addr - map[i-1].addr);
+	else sprintf(buf, "%s", map[i-1].name);
+	return buf;
+}
+
 
 // Register class
 
@@ -147,7 +172,7 @@ static void print_var (op_var_t * var)
 
 			// Near address is relative
 
-			printf ("%.4x", (word_t) ((short) op_code_off + var->val.s));
+			printf ("%s", text_symbol((word_t) ((short) op_code_off + var->val.s)));
 			break;
 
 		}


### PR DESCRIPTION
Here's my 20-line hack to add displaying symbols from any ia86-elf-gcc/ld.gold produced executable during disassembly tracing in EMU86. I think it's pretty cool. The following shows ELKS making a system call and saving the CPU registers onto a kernel stack:
<img width="752" alt="map file2" src="https://user-images.githubusercontent.com/11985637/118408267-1157de00-b642-11eb-983d-f477092687c8.png">

I think once we get used to this, we won't want to live without it.

Currently, only near text segment addresses are converted. Adding far text and data will be very straightforward, except for the problem of knowing the start segment values for each. Current hack doesn't check for proper text segment. 

ELKS displays text, far text and data segments at boot.

The following is required to make this work:

Add ELKS patch to produce `ia16-elf-nm` symbol listing from ELF binary before `elf2elks` conversion:
```
diff --git a/elks/arch/i86/Makefile b/elks/arch/i86/Makefile
index 337adc84..cd08b422 100644
--- a/elks/arch/i86/Makefile
+++ b/elks/arch/i86/Makefile
@@ -132,10 +132,11 @@ else
 # Begin PC image build
 
 boot/system:   $(XINCLUDE) $(AARCHIVES) $(ADRIVERS) boot/crt0.o
-       (cd $(BASEDIR) ; $(LD) $(LDFLAGS) -M $(ARCH_LD) -T $(TOPDIR)/elks/elks-small.ld \
+       (cd $(BASEDIR) ; $(LD) $(CPU_LD) -M $(ARCH_LD) -T $(TOPDIR)/elks/elks-small.ld \
                $(ARCH_DIR)/boot/crt0.o \
                init/main.o '-(' $(ARCHIVES) $(DRIVERS) '-)' $(LIBGCC) \
                -o $(ARCH_DIR)/boot/system > $(ARCH_DIR)/boot/system.map ; \
+               ia16-elf-nm $(ARCH_DIR)/boot/system > $(ARCH_DIR)/boot/system-nm.map; \
                $(POSTLINK) $(ROMPOSTLINKFLAGS) $(ARCH_DIR)/boot/system)
 #              sort -k3,4 $(ARCH_DIR)/boot/system.tmp > $(ARCH_DIR)/boot/system.map ; \
 #              rm -f $(ARCH_DIR)/boot/system.tmp )
```


Run convmap.sh, which produces a mapfile.c from the ELKS or other namelist file:
```
Gregs-MBP2:emu86 greg$ cat convmap.sh
cat ../elks-gh/elks/arch/i86/boot/system-nm.map | sed -e '/&/d; /!/d' | sort > file
cc convmap.c -o convmap
./convmap > mapfile.c
rm file
```
The preprocessing removes any symbols ending in '&' or '!'. The symbols are then sorted and converted to a C file.

A quick change would be keeping the symbol address unchanged in mapfile.c, which allows keeping all symbols in a single array. Linear brute sweep, rather than binary search, is employed to find the symbol.

The pre-processing should probably all be done inside EMU86, and build a dynamic array instead. This would allow map files to be used without conversion or recompilation. We just need to think of a way of finding out the proper segment values for the 0x10000, 0x20000 and 0x30000 symbol ranges in the map file. At last resort, we could compile in a special symbol that would tell us this from ELKS kernel.

Have fun!