### PR TITLE
int-8018x: add nonspecific EOI

### DIFF
--- a/int-8018x.c
+++ b/int-8018x.c
@@ -46,8 +46,15 @@ int int_io_write (word_t p, word_t w)
 
 	if (r == INT_REG_EOI)
 		{
-		if ((w & 0x001F) == 0x0008) int_end_line (INT_LINE_TIMER0);
-		if ((w & 0x001F) == 0x0014) int_end_line (INT_LINE_SERIAL);
+		if (w == 0x8000)
+			{
+			int_end_prio ();
+			}
+		else
+			{
+			if ((w & 0x001F) == 0x0008) int_end_line (INT_LINE_TIMER0);
+			if ((w & 0x001F) == 0x0014) int_end_line (INT_LINE_SERIAL);
+			}
 		}
 
 	else if (r == INT_REG_MASK)


### PR DESCRIPTION
8018X have a means to execute a nonspecific EOI to acknowledge all
interrupts when setting the MSB bit on the EOI register (i.e. 0x8000).
Implement this behavior on the int-8018x.c file.