### PR TITLE
timer-801x.inc: Timer2 control reg index fix

### DIFF
--- a/timer-8018x.inc
+++ b/timer-8018x.inc
@@ -9,7 +9,7 @@
 
 #define TIMER2_COUNT   8   // timer 2 count register
 #define TIMER2_MAX     9   // timer 2 max register
-#define TIMER2_MODE    10  // timer 2 mode & control register
+#define TIMER2_MODE    11  // timer 2 mode & control register
 
 static word_t timer_regs [TIMER_REG_COUNT];
 


### PR DESCRIPTION
Fixes the register number that's being used on the timer-8018x.inc
when accessing the Timer2 mode/control register. It should be
PCB + 0x46 which ends up in item 11 on timer_regs.