### PR TITLE
Add IMUL 0x69 and 0x6B op-codes

### DIFF
--- a/op-class.c
+++ b/op-class.c
@@ -716,10 +716,16 @@ static int class_1_40h (byte_t code, op_desc_t * op_desc)
 				break;
 				}
 
+			// 0x69 E 0x6B
+			if ((code&0xd) == 0x9) {
+				OP_ID = OP_IIMUL;
+				fetch_code_2 (op_desc);
+				err = class_w_mod_rm_imm( (code & 0x2)? CF_S:0, op_desc);
+				break;
+				}
+
 			// TODO: complete with 80186 opcodes
 			// 0x62: BOUND
-			// 0x69: IMUL imm16
-			// 0x6B: IMUL imm8
 			// 0x6C: INS p8
 			// 0x6D: INS p16
 			// 0x6E: OUTS p8

--- a/op-class.h
+++ b/op-class.h
@@ -82,6 +82,7 @@ struct op_desc_s
 	byte_t   var_wb;    // operand is =1 byte, =2 word (for printing)
 	op_var_t var_to;    // optional single or 'to' operand
 	op_var_t var_from;  // optional 'from' operand
+	op_var_t var_from2; // optional 'from2' operand
 
 	// opcode 1 byte fields
 

--- a/op-exec.c
+++ b/op-exec.c
@@ -563,6 +563,16 @@ static word_t alu_calc_2 (word_t op, byte_t w, word_t a, word_t b)
 			r = a ^ b;
 			break;
 
+		case OP_IIMUL:
+			r = a * b;
+
+			co = (~a & b) | (~(a ^ b) & r);
+			ci = a ^ b ^ r;
+
+			cf = co & m;
+			of = ci & m;
+			break;
+
 		default:
 			assert (0);
 
@@ -1702,6 +1712,8 @@ static op_id_hand_t _id_hand_tab [] = {
 
 	{ OP_ENTER,    op_enter     },
 	{ OP_LEAVE,    op_leave     },
+
+	{OP_IIMUL,     op_calc_2	},
 
 	{ OP_NULL,     NULL         }  // end of table
 	};

--- a/op-exec.c
+++ b/op-exec.c
@@ -563,18 +563,6 @@ static word_t alu_calc_2 (word_t op, byte_t w, word_t a, word_t b)
 			r = a ^ b;
 			break;
 
-		/*
-		case OP_IMUL3:
-			r = a * b;
-
-			co = (~a & b) | (~(a ^ b) & r);
-			ci = a ^ b ^ r;
-
-			cf = co & m;
-			of = ci & m;
-			break;
-		*/
-
 		default:
 			assert (0);
 
@@ -1725,7 +1713,7 @@ static op_id_hand_t _id_hand_tab [] = {
 	{ OP_ENTER,    op_enter     },
 	{ OP_LEAVE,    op_leave     },
 
-	{OP_IMUL3,     op_calc_3    },
+	{ OP_IMUL3,    op_calc_3    },
 
 	{ OP_NULL,     NULL         }  // end of table
 	};

--- a/op-exec.c
+++ b/op-exec.c
@@ -563,7 +563,8 @@ static word_t alu_calc_2 (word_t op, byte_t w, word_t a, word_t b)
 			r = a ^ b;
 			break;
 
-		case OP_IIMUL:
+		/*
+		case OP_IMUL3:
 			r = a * b;
 
 			co = (~a & b) | (~(a ^ b) & r);
@@ -572,6 +573,7 @@ static word_t alu_calc_2 (word_t op, byte_t w, word_t a, word_t b)
 			cf = co & m;
 			of = ci & m;
 			break;
+		*/
 
 		default:
 			assert (0);
@@ -1447,6 +1449,7 @@ static int op_loop (op_desc_t * op_desc)
 	return 0;
 	}
 
+
 // XLAT
 
 static int op_xlat (op_desc_t * op_desc)
@@ -1464,7 +1467,7 @@ static int op_xlat (op_desc_t * op_desc)
 	}
 
 
-// Enter/Leave
+// Enter & Leave
 
 static int op_enter (op_desc_t * op_desc)
 	{
@@ -1530,7 +1533,7 @@ static int op_adjust2 (op_desc_t * op_desc)
 
 	op_var_t * var = &op_desc->var_to;
 	assert (var->type == VT_IMM);
-	
+
 	byte_t tempAL = reg8_get(REG_AL);
 	byte_t tempAH = reg8_get(REG_AH);
 
@@ -1555,6 +1558,15 @@ static int op_adjust2 (op_desc_t * op_desc)
 
 	return 0;
 	}
+
+
+// Special IMUL with 3 operands
+
+static int op_calc_3 (op_desc_t * op_desc)
+	{
+	return -1;
+	}
+
 
 // Table of operation handlers
 
@@ -1713,7 +1725,7 @@ static op_id_hand_t _id_hand_tab [] = {
 	{ OP_ENTER,    op_enter     },
 	{ OP_LEAVE,    op_leave     },
 
-	{OP_IIMUL,     op_calc_2	},
+	{OP_IMUL3,     op_calc_3    },
 
 	{ OP_NULL,     NULL         }  // end of table
 	};

--- a/op-id-name.c
+++ b/op-id-name.c
@@ -108,6 +108,7 @@ static op_id_name_t id_name_tab [] = {
 	{ OP_XCHG,   "XCHG"   },
 	{ OP_XLAT,   "XLAT"   },
 	{ OP_XOR,    "XOR"    },
+	{ OP_IMUL3,  "IMUL"   },
 	{ OP_NULL,   NULL     }
 	};
 

--- a/op-id.h
+++ b/op-id.h
@@ -170,4 +170,8 @@
 #define OP_ENTER    0x006D
 #define OP_LEAVE    0x006E
 
+// todo: Put somewhere more adequate
+// Integer Imediate multiply
+#define OP_IIMUL	0x006F
+
 // LUT END

--- a/op-id.h
+++ b/op-id.h
@@ -170,8 +170,10 @@
 #define OP_ENTER    0x006D
 #define OP_LEAVE    0x006E
 
-// todo: Put somewhere more adequate
-// Integer Imediate multiply
-#define OP_IIMUL	0x006F
+// 8086 IMUL has implicit accumulator operand and is mapped to CALC1
+// while 80186 has special IMUL with 3 explicit operands mapped to CALC3
+// so use another operation ID for that special IMUL
+
+#define OP_IMUL3    0x006F
 
 // LUT END

--- a/op-print-att.c
+++ b/op-print-att.c
@@ -209,6 +209,12 @@ void print_op (op_desc_t * op_desc)
 
 	byte_t count = op_desc->var_count;
 
+	if (count >= 3)
+		{
+		print_var (&(op_desc->var_from2));
+		putchar (',');
+		}
+
 	if (count >= 2)
 		{
 		print_var (&(op_desc->var_from));

--- a/op-print-intel.c
+++ b/op-print-intel.c
@@ -194,4 +194,13 @@ void print_op (op_desc_t * op_desc)
 		if (op_desc->var_wb) printf ((op_desc->var_wb == VP_WORD) ? "WORD ": "BYTE ");
 		print_var (&(op_desc->var_from));
 		}
+
+	if (count == 3)
+		{
+		print_var (&(op_desc->var_to));
+		putchar (',');
+		print_var (&(op_desc->var_from));
+		putchar (',');
+		print_var (&(op_desc->var_from2));
+		}
 	}


### PR DESCRIPTION
I need to emulate a 80C188EB for a legacy code which uses the 0x6B instruction inside a microcontroller. I have never done anything like, so I have no idea if this is the proper approach. I am more interested in comments about the implementation than the pull of this request