### PR TITLE
Add symbolic instruction tracing for kernel using system.sym symbol table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ ifeq ($(TARGET), pcxtat)
 	PLATFORM = 8xxx
 	BOARD = pcxtat
 	EMU86_OBJS += rom-bios.o rom-pcxtat.o
+	EMU86_OBJS += syms.o
 endif
 
 ifeq ($(TARGET), elks)

--- a/config.mk
+++ b/config.mk
@@ -46,5 +46,5 @@ SERIAL=none
 # att:   AT&T syntax (GNU default)
 # intel: Intel syntax
 
-#STYLE=att
-STYLE=intel
+STYLE=att
+#STYLE=intel

--- a/emu-proc.c
+++ b/emu-proc.c
@@ -148,13 +148,13 @@ void regs_print ()
 	word_t ip = reg16_get (REG_IP);
 	word_t fl = reg16_get (REG_FL);
 
-	printf ("AX %.4hX  BX %.4hX  CX %.4hX  DX %.4hX  FL %.4hX\n", ax, bx, cx, dx, fl);
-	printf ("SI %.4hX  DI %.4hX  IP %.4hX  SP %.4hX  BP %.4hX\n", si, di, ip, sp, bp);
-	printf ("DS %.4hX  ES %.4hX  CS %.4hX  SS %.4hX\n", ds, es, cs, ss);
+	printf ("  AX %.4hX  BX %.4hX  CX %.4hX  DX %.4hX  FL %.4hX\n", ax, bx, cx, dx, fl);
+	printf ("  SI %.4hX  DI %.4hX  IP %.4hX  SP %.4hX  BP %.4hX\n", si, di, ip, sp, bp);
+	printf ("  DS %.4hX  ES %.4hX  CS %.4hX  SS %.4hX\n", ds, es, cs, ss);
 
 	// TODO: invert flag order
 
-	printf ("\nCF %hhu  PF %hhu  AF %hhu  ZF %hhu  SF %hhu  TF %hhu  IF %hhu  DF %hhu  OF %hhu\n",
+	printf ("  CF %hhu PF %hhu AF %hhu ZF %hhu SF %hhu TF %hhu IF %hhu DF %hhu OF %hhu\n",
 		flag_get (FLAG_CF), flag_get (FLAG_PF), flag_get (FLAG_AF),
 		flag_get (FLAG_ZF), flag_get (FLAG_SF), flag_get (FLAG_TF),
 		flag_get (FLAG_IF), flag_get (FLAG_DF), flag_get (FLAG_OF));

--- a/emu86.sh
+++ b/emu86.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Run ELKS in EMU86 (basic 8086 emulator)
+# EMU86 is part of the cross tools
+
+# For ELKS ROM Configuration:
+# ELKS must be configured minimaly with 'cp emu86-rom.config .config'
+# This uses headless console, HLT on idle, ROM filesystem.
+
+# First build ELKS with kernel and root FS in ROM
+# Kernel image @ segment 0xE000 (top of 1024K address space)
+# Root filesystem @ segment 0x8000 (assumes 512K RAM & 512K ROM)
+# Skip the INT 19h bootstrap in the kernel image (+0x14)
+
+ELKSDIR=../elks-gh/
+
+#exec ./emu86 -i -w 0xe0000 -f Image -w 0x80000 -f romfs.bin
+exec ./emu86 \
+	-C 0xe062 -D 0x00c0 \
+    -w 0xe0000 -f ${ELKSDIR}elks/arch/i86/boot/Image \
+    -w 0x80000 -f ${ELKSDIR}image/romfs.bin \
+    -S ${ELKSDIR}elks/arch/i86/boot/system.sym
+
+#exec emrun --serve_after_close emu86.html -- -v3 -w 0x10000 -x 0x1000:0x34 -f romfs.bin
+
+# For ELKS disk image Configuration:
+# ELKS must be configured with 'cp emu86-disk.config .config'
+# This uses headless console, HLT on idle, no CONFIG_IDE_PROBE
+
+exec ./emu86 -v0 -I ../elks-gh/image/fd1440.bin -M ../elks-gh/elks/arch/i86/boot/system-nm.map
+#exec ./emu86 -v0 -I fd.img
+#exec ./emu86 -I ../elks-gh/image/fd1440.bin -I ../elks-gh/image/hd32-minix.bin ${1+"$@"}
+#exec ./emu86 -I ../elks-gh/image/fd360-minix.bin ${1+"$@"}
+#exec ./emu86 -I ../elks-gh/image/fd1440-fat.bin ${1+"$@"}
+#exec ./emu86 -i -I ../elks-gh/image/hd32-minix.bin ${1+"$@"}
+#exec ./emu86 -I ../elks-gh/image/hd32mbr-minix.bin ${1+"$@"}
+exec ./emu86 -I ../elks-gh/image/hd32-fat.bin ${1+"$@"}

--- a/op-print-att.c
+++ b/op-print-att.c
@@ -11,10 +11,13 @@
 #include "op-common.h"
 #include "op-class.h"
 
+#include "syms.h"
+#include "emu-proc.h"
 
 // Opcode helpers
 
 extern word_t op_code_off;
+extern unsigned int sym_code, sym_data;
 
 char op_code_str [3 * OPCODE_MAX + 2];
 byte_t op_code_pos;
@@ -59,7 +62,13 @@ static void print_mem (byte_t flags, short rel)
 			}
 		else
 			{
-			printf ("0x%hx", (word_t) rel);
+			if (seg_get(SEG_DS) == sym_data)
+				{
+				printf ("%s", sym_data_symbol((void *)(long)(unsigned short)
+					((word_t) rel), -1));
+				}
+			else
+				printf ("0x%hx", (word_t) rel);
 			}
 		}
 
@@ -147,6 +156,12 @@ static void print_var (op_var_t * var)
 
 			// Near address is relative
 
+			if (seg_get(SEG_CS) == sym_code)
+				{
+				printf ("%s", sym_text_symbol((void *)(long)(unsigned short)
+					((short) op_code_off + var->val.s), -1));
+				break;
+				}
 			printf ("%.4x", (word_t) ((short) op_code_off + var->val.s));
 			break;
 

--- a/op-print-intel.c
+++ b/op-print-intel.c
@@ -11,10 +11,13 @@
 #include "op-common.h"
 #include "op-class.h"
 
+#include "syms.h"
+#include "emu-proc.h"
 
 // Opcode helpers
 
 extern word_t op_code_off;
+extern unsigned int sym_code, sym_data;
 
 char op_code_str [3 * OPCODE_MAX + 2];
 byte_t op_code_pos;
@@ -86,7 +89,13 @@ static void print_mem (byte_t flags, short rel)
 			}
 		else
 			{
-			printf ("%hXh", (word_t) rel);
+			if (seg_get(SEG_DS) == sym_data)
+				{
+				printf ("%s", sym_data_symbol((void *)(long)(unsigned short)
+					((word_t) rel), -1));
+				}
+			else
+				printf ("%hXh", (word_t) rel);
 			}
 		}
 
@@ -141,6 +150,12 @@ static void print_var (op_var_t * var)
 
 			// Near address is relative
 
+			if (seg_get(SEG_CS) == sym_code)
+				{
+				printf ("%s", sym_text_symbol((void *)(long)(unsigned short)
+					((short) op_code_off + var->val.s), -1));
+				break;
+				}
 			printf ("%.4Xh", (word_t) ((short) op_code_off + var->val.s));
 			break;
 

--- a/rom-bios.c
+++ b/rom-bios.c
@@ -33,6 +33,15 @@ void rom_init_0 (void)
 	mem_stat [0xF1007] = 0x06;
 	mem_stat [0xF1008] = 0x6C;
 	mem_stat [0xF1009] = 0x04;
+
+	mem_stat [0xF1006] = 0x90;  // NOP
+	mem_stat [0xF1007] = 0x90;  // NOP
+	mem_stat [0xF1008] = 0x90;  // NOP
+	mem_stat [0xF1009] = 0x90;  // NOP
+
+	mem_stat [0xF1006] = 0xCD;  // INT 1C
+	mem_stat [0xF1007] = 0x1C;
+
 	mem_stat [0xF100A] = 0xB0;  // MOV AL,20h
 	mem_stat [0xF100B] = 0x20;
 	mem_stat [0xF100C] = 0xE6;  // OUT 20h,AL
@@ -47,6 +56,13 @@ void rom_init_0 (void)
 	mem_stat [0x08 * 4 + 1] = 0x10;
 	mem_stat [0x08 * 4 + 2] = 0x00;
 	mem_stat [0x08 * 4 + 3] = 0xF0;
+
+	// Point vector 1Ch to IRET
+
+	mem_stat [0x1C * 4 + 0] = 0x10;
+	mem_stat [0x1C * 4 + 1] = 0x10;
+	mem_stat [0x1C * 4 + 2] = 0x00;
+	mem_stat [0x1C * 4 + 3] = 0xF0;
 	}
 
 

--- a/syms.c
+++ b/syms.c
@@ -1,0 +1,262 @@
+/*
+ * ELKS symbol table support
+ *
+ * July 2022 Greg Haerr
+ */
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include "syms.h"
+
+static unsigned char __far *syms;
+
+#if __ELKS__
+#include <linuxmt/minix.h>
+struct minix_exec_hdr sym_hdr;
+#endif
+
+#define MAGIC       0x0301  /* magic number for executable progs */
+
+#ifdef _M_I86
+static void noinstrument cfmemcpy(unsigned char __far *dst, unsigned char *src, int n)
+{
+    do {
+        *dst++ = *src++;
+    } while (--n);
+}
+#endif
+
+/* allocate space and read symbol table */
+static unsigned char __far * noinstrument alloc_read(int fd, size_t size)
+{
+    if (size == 0 || size > 32767)
+        return NULL;
+#ifdef _M_I86
+    unsigned char __far *s;
+    size_t n, t = 0;
+    static unsigned char buf[512];  /* don't use application stack */
+
+    if (!(s = fmemalloc(size)))
+        return NULL;
+    do {
+        n = size > sizeof(buf)? sizeof(buf): size;
+        if (read(fd, buf, n) != n)
+            return NULL;            // FIXME no fmemfree
+        cfmemcpy(s+t, buf, n);
+        t += n;
+        size -= n;
+    } while (size);
+    return s;
+#else
+    unsigned char *s;
+    if (!(s = malloc(size)))
+        return NULL;
+    if (read(fd, s, size) != size)
+        return NULL;
+    return (unsigned char __far *)s;
+#endif
+}
+
+#if __ELKS__
+/* read symbol table from executable into memory */
+unsigned char __far * noinstrument sym_read_exe_symbols(char *path)
+{
+    int fd;
+    unsigned char __far *s;
+    char fullpath[PATH_MAX];
+
+    if (syms) return syms;
+    if ((fd = open(path, O_RDONLY)) < 0) {
+        strcpy(fullpath, "/bin/");          // FIXME use path
+        strcpy(fullpath+5, path);
+        if ((fd = open(fullpath, O_RDONLY)) < 0)
+                return NULL;
+    }
+    errno = 0;
+    if (read(fd, &sym_hdr, sizeof(sym_hdr)) != sizeof(sym_hdr)
+        || ((sym_hdr.type & 0xFFFF) != MAGIC)
+        || (lseek(fd, -(int)sym_hdr.syms, SEEK_END) < 0)
+        || !(s = alloc_read(fd, (size_t)sym_hdr.syms))) {
+            int e = errno;
+            close(fd);
+            errno = e;
+            return NULL;
+    }
+    close(fd);
+    syms = s;
+    return syms;
+}
+#endif
+
+/* read symbol table file into memory */
+unsigned char __far * noinstrument sym_read_symbols(char *path)
+{
+    int fd;
+    unsigned char __far *s;
+    struct stat sbuf;
+
+    if (syms) return syms;
+    if ((fd = open(path, O_RDONLY)) < 0)
+        return NULL;
+    errno = 0;
+    if (fstat(fd, &sbuf) < 0
+        || !(s = alloc_read(fd, (size_t)sbuf.st_size))) {
+            int e = errno;
+            close(fd);
+            errno = e;
+            return NULL;
+    }
+    close(fd);
+    syms = s;
+    return syms;
+}
+
+static int noinstrument type_text(unsigned char __far *p)
+{
+    return (p[TYPE] == 'T' || p[TYPE] == 't' || p[TYPE] == 'W');
+}
+
+static int noinstrument type_ftext(unsigned char __far *p)
+{
+    return (p[TYPE] == 'F' || p[TYPE] == 'f');
+}
+
+static int noinstrument type_data(unsigned char __far *p)
+{
+    return (p[TYPE] == 'D' || p[TYPE] == 'd' ||
+            p[TYPE] == 'B' || p[TYPE] == 'b' ||
+            p[TYPE] == 'V');
+}
+
+static char * noinstrument hexout(char *buf, unsigned int v, int zstart)
+{
+    int sh = 12;
+
+    do {
+        int c = (v >> sh) & 15;
+        if (!c && sh > zstart)
+            continue;
+        if (c > 9)
+            *buf++ = 'a' - 10 + c;
+        else
+            *buf++ = '0' + c;
+    } while ((sh -= 4) >= 0);
+    *buf = '\0';
+    return buf;
+}
+
+static char * noinstrument hex(char *buf, unsigned int v)
+{
+    return hexout(buf, v, 0);   /* %x */
+}
+
+static char * noinstrument hex4(char *buf, unsigned int v)
+{
+    return hexout(buf, v, 12);  /* %04x */
+}
+
+static char * noinstrument fstrncpy(char *dst, unsigned char __far *src, int n)
+{
+    do {
+        *dst++ = *src++;
+    } while (--n);
+    *dst = '\0';
+    return dst;
+}
+
+/*
+ * Convert address to symbol string+offset,
+ * offset = 0 don't show offset, offset = -1 no offset specified.
+ */
+static char * noinstrument sym_string(void *addr, int offset,
+    int (*istype)(unsigned char __far *p))
+{
+    unsigned char __far *p;
+    unsigned char __far *lastp;
+    char *cp;
+    static char buf[64];
+
+    if (!syms) {
+hex:
+        if (!offset || offset == -1) {
+            hex4(buf, (size_t)addr);
+        } else {
+            cp = hex4(buf, (size_t)addr-offset);
+            *cp++ = '+';
+            hex(cp, offset);
+        }
+        return buf;
+    }
+
+    lastp = syms;
+    while (!istype(lastp)) {
+        lastp = next(lastp);
+        if (!lastp[TYPE])
+            goto hex;
+    }
+    for (p = next(lastp); ; lastp = p, p = next(p)) {
+        if (!istype(p) || ((unsigned short)addr < *(unsigned short __far *)(&p[ADDR])))
+            break;
+    }
+    int lastaddr = *(unsigned short __far *)(&lastp[ADDR]);
+    if (offset && addr - lastaddr) {
+        cp = fstrncpy(buf, lastp+SYMBOL, lastp[SYMLEN]);
+        *cp++ = '+';
+        hex(cp, (size_t)addr - lastaddr);
+    } else {
+        fstrncpy(buf, lastp+SYMBOL, lastp[SYMLEN]);
+    }
+    return buf;
+}
+
+/* convert .text address to symbol */
+char * noinstrument sym_text_symbol(void *addr, int offset)
+{
+    return sym_string(addr, offset, type_text);
+}
+
+/* convert .fartext address to symbol */
+char * noinstrument sym_ftext_symbol(void *addr, int offset)
+{
+    return sym_string(addr, offset, type_ftext);
+}
+
+/* convert .data address to symbol */
+char * noinstrument sym_data_symbol(void *addr, int offset)
+{
+    return sym_string(addr, offset, type_data);
+}
+
+#if UNUSED
+/* map .text address to function start address */
+void * noinstrument sym_fn_start_address(void *addr)
+{
+    unsigned char __far *p;
+    unsigned char __far *lastp;
+
+    if (!syms) return NULL;
+    lastp = syms;
+    for (p = next(lastp); ; lastp = p, p = next(p)) {
+        if (!type_text(p) || ((unsigned short)addr < *(unsigned short __far *)(&p[ADDR])))
+            break;
+    }
+    return (void *) (intptr_t) *(unsigned short __far *)(&lastp[ADDR]);
+}
+
+static int noinstrument type_any(unsigned char *p)
+{
+    return p[TYPE] != '\0';
+}
+
+/* convert (non-segmented local IP) address to symbol */
+char * noinstrument sym_symbol(void *addr, int offset)
+{
+    return sym_string(addr, offset, type_any);
+}
+#endif

--- a/syms.h
+++ b/syms.h
@@ -1,0 +1,34 @@
+/* ELKS symbol table support */
+#if defined(__ia16__) || defined(__WATCOMC__)
+#include <sys/cdefs.h>
+#else
+#define noinstrument
+#define __far
+#endif
+
+/* symbol table format
+ *  | byte type | word address | byte symbol length | symbol |
+ *  type: (lower case means static)
+ *      T, t    .text
+ *      F, f    .fartext
+ *      D, d    .data
+ *      B, b    .bss
+ *      0       end of symbol table
+ */
+
+#define next(sym)   \
+    ((sym) + 1 + sizeof(unsigned short) + ((unsigned char __far *)sym)[SYMLEN] + 1)
+#define TYPE        0
+#define ADDR        1
+#define SYMLEN      3
+#define SYMBOL      4
+
+unsigned char __far * noinstrument sym_read_exe_symbols(char *path);
+unsigned char __far * noinstrument sym_read_symbols(char *path);
+char * noinstrument sym_text_symbol(void *addr, int offset);
+char * noinstrument sym_ftext_symbol(void *addr, int offset);
+char * noinstrument sym_data_symbol(void *addr, int offset);
+char * noinstrument sym_symbol(void *addr, int offset);
+void * noinstrument sym_fn_start_address(void *addr);
+
+extern struct minix_exec_hdr sym_hdr;

--- a/timer-8xxx.c
+++ b/timer-8xxx.c
@@ -8,7 +8,7 @@
 #include "int-8xxx.h"
 #include "mem-io-pcxtat.h"
 
-#define TIMER_MAX 3000
+#define TIMER_MAX 30000
 
 static int timer_enabled = 1;
 static int timer_count = 0;


### PR DESCRIPTION
Adds enhancements to allow the complete emulation of the ELKS kernel from startup through normal operation using the kernel symbol table for easy understanding of instruction sequences. 

The following enhancements are included:
- Symbols displayed from kernel .text and .data segments automatically.
- Instructions displayed by default in AT&T rather than Intel format (see config.mk STYLE=att).
- R command toggles register display between instructions.
- C command displays registers with continuous execution, c command does not.
- Command line option -S for symbol table path.
- Command line option -C for symbol table .text segment address.
- Command line option -D for symbol table .data segment address.
- Adds emu86.sh to automatically run just-compiled version of ELKS kernel from `em86-rom-full.config` configuration file.
- Optional INT 1C BIOS timer callback support added (use CONFIG_TIMER_INT1C=y).
- Emulated INT 8 (IRQ 0) timer changed to fire every 30000 rather than 3000 instructions.
- Optional SDL console available with CONSOLE=sdl in config.mk

To build kernel and test:
```
EMU86=../emu86
$ cd $TOPDIR
$ cp emu86-rom-full.config .config
$ make clean
$ make
$ cd $EMU86
$ ./emu86.sh
info: symtabl text segment  0E062h
info: symtabl data segment  000C0h
info: load address E0000h
info: load file ../elks-gh/elks/arch/i86/boot/Image
info: file size=10CE0h
success: file loaded
info: load address 80000h
info: load file ../elks-gh/image/romfs.bin
info: file size=20189h
success: file loaded
info: symbols file ../elks-gh/elks/arch/i86/boot/system.sym

ELKS Setup INT f000 START
Headless console
32K ext buffers, 8K cache, 1 req hdrs
fd: no get drive fn, ndrives 0
PC/AT class cpu 2, syscaps 30, 512K base ram, 16 tasks, 64 files, 96 inodes
ELKS 0.9.0-dev (59968 text, 0 ftext, 7296 data, 5440 bss, 52798 heap)
Kernel text e062 data c0 end 10c0 top 8000 445+0+0K free
VFS: Mounted root device /dev/rom (0600) romfs filesystem.
Running /etc/rc.sys script
Wed Aug 21 09:47:13 1991

ELKS 0.9.0-dev

[0.18 secs] login: ^C
E062:2D4F  75 03              jnz     schedule+98
>c
E062:2D51  8B 5F 16           mov     0x16(%bx),%bx
E062:2D54  FB                 sti     
E062:2D55  39 F3              cmp     %si,%bx
E062:2D57  74 8E              jz      schedule+2b
E062:2CE7  89 EC              mov     %bp,%sp
E062:2CE9  5D                 pop     %bp
E062:2CEA  5F                 pop     %di
E062:2CEB  5E                 pop     %si
E062:2CEC  C3                 ret     
E062:0172  E8 5D 9C           call    idle_halt
E062:9DD2  F4                 hlt     
E062:9DD3  C3                 ret     
E062:0175  EB D8              jmp     idle_loop+e
E062:014F  8B 1E 3A 2A        mov     idle_task,%bx
E062:0153  81 BF A4 00 76 54  cmpw    $0x5476,0xa4(%bx)
E062:0159  74 14              jz      idle_loop+2e
E062:016F  E8 4A 2B           call    schedule
E062:2CBC  56                 push    %si
E062:2CBD  57                 push    %di
E062:2CBE  55                 push    %bp
E062:2CBF  89 E5              mov     %sp,%bp
^C
...
```
To start the kernel and see each instruction step-by-step from boot, add `-i` to the emu86 command line in emu86.sh.

